### PR TITLE
Fix incorrect operationId for MS Tenants :PUT method

### DIFF
--- a/lib/swagger/swagger.yaml
+++ b/lib/swagger/swagger.yaml
@@ -1958,7 +1958,7 @@ paths:
 
     put:
       summary: update tenant
-      operationId: updateAccount
+      operationId: putTenant
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Due to a duplicate (incorrect) operationId on the MS Tenants :PUT method when I toggle the :PUT for Accounts endpoint it also toggles the MS Tenants endpoint open as well.

<img width="1792" alt="Screen Shot 2021-08-16 at 8 32 07 AM" src="https://user-images.githubusercontent.com/438711/129589457-f2c44ae6-0e46-4ba5-875b-dd399dfb7d0f.png">
