### PR TITLE
Allow falsy values for force_change and Is_active in PUT user call

### DIFF
--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -305,12 +305,12 @@ router.put('/:user_sid', async(req, res) => {
       if (0 === r.changedRows) throw new Error('database update failed');
     }
 
-    if (is_active) {
+    if (is_active || is_active === false) {
       const r = await promisePool.execute('UPDATE users SET is_active = ? WHERE user_sid = ?', [is_active, user_sid]);
       if (0 === r.changedRows) throw new Error('database update failed');
     }
 
-    if (force_change) {
+    if (force_change || force_change === false) {
       const r = await promisePool.execute(
         'UPDATE users SET force_change = ? WHERE user_sid = ?',
         [force_change, user_sid]);

--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -305,12 +305,12 @@ router.put('/:user_sid', async(req, res) => {
       if (0 === r.changedRows) throw new Error('database update failed');
     }
 
-    if (is_active || is_active === false) {
+    if (typeof is_active !== 'undefined') {
       const r = await promisePool.execute('UPDATE users SET is_active = ? WHERE user_sid = ?', [is_active, user_sid]);
       if (0 === r.changedRows) throw new Error('database update failed');
     }
 
-    if (force_change || force_change === false) {
+    if (typeof force_change !== 'undefined') {
       const r = await promisePool.execute(
         'UPDATE users SET force_change = ? WHERE user_sid = ?',
         [force_change, user_sid]);


### PR DESCRIPTION
is_active and force_change was updated only when values were truthy. 
Now we allow the values to be updated also as false.

This was not allowing the User to be deactivated or password not be forced to be changed when updating users from the new webapp. 

Related Webapp PR: https://github.com/jambonz/jambonz-webapp/pull/178