### PR TITLE
Return scoped carriers and speech creds in /SP GET call

### DIFF
--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -128,6 +128,12 @@ router.get('/:sid/VoipCarriers', async(req, res) => {
     await validateRetrieve(req);
     const service_provider_sid = parseServiceProviderSid(req);
     const results = await VoipCarrier.retrieveAllForSP(service_provider_sid);
+    console.log(results);
+
+    if (req.user.hasScope('account')) {
+      return res.status(200).json(results.filter((r) => r.account_sid === req.user.account_sid || !r.account_sid));
+    }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -127,14 +127,13 @@ router.get('/:sid/VoipCarriers', async(req, res) => {
   try {
     await validateRetrieve(req);
     const service_provider_sid = parseServiceProviderSid(req);
-    const results = await VoipCarrier.retrieveAllForSP(service_provider_sid);
-    console.log(results);
+    const carriers = await VoipCarrier.retrieveAllForSP(service_provider_sid);
 
     if (req.user.hasScope('account')) {
-      return res.status(200).json(results.filter((r) => r.account_sid === req.user.account_sid || !r.account_sid));
+      return res.status(200).json(carriers.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid));
     }
 
-    res.status(200).json(results);
+    res.status(200).json(carriers);
   } catch (err) {
     sysError(logger, res, err);
   }

--- a/lib/routes/api/speech-credentials.js
+++ b/lib/routes/api/speech-credentials.js
@@ -151,9 +151,13 @@ router.get('/', async(req, res) => {
   if (!account_sid) service_provider_sid = parseServiceProviderSid(req);
   const logger = req.app.locals.logger;
   try {
-    const creds = account_sid ?
+    let creds = account_sid ?
       await SpeechCredential.retrieveAll(account_sid) :
       await SpeechCredential.retrieveAllForSP(service_provider_sid);
+
+    if (req.user.hasScope('account')) {
+      creds = creds.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid);
+    }
 
     res.status(200).json(creds.map((c) => {
       const {credential, ...obj} = c;


### PR DESCRIPTION
Related Webapp PR: https://github.com/jambonz/jambonz-webapp/pull/179

This PR fixes issue where /SP GET call fro VoipCarriers or Speech would return all SP-related resources. 
In the webapp we use a /SP call for listing combined lists, so it should be limited for account scope users.