### PR TITLE
Add check to not allow the same password to be user as new

### DIFF
--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -285,6 +285,11 @@ router.put('/:user_sid', async(req, res) => {
         //debug(`PUT /Users/:sid pwd ${old_password} does not match hash ${old_hashed_password}`);
         return res.sendStatus(403);
       }
+
+      if (old_password === new_password) {
+        throw new Error('new password cannot be your old password');
+      }
+
       const passwordHash = await generateHashedPassword(new_password);
       //debug(`updating hashed_password to ${passwordHash}`);
       const r = await promisePool.execute(updateSql, [passwordHash, user_sid]);


### PR DESCRIPTION
Password change accepts old password to be the new password, this is not considered safe practice.
