### PR TITLE
Speech should always be attached to an SP

### DIFF
--- a/lib/routes/api/add-from-predefined-carrier.js
+++ b/lib/routes/api/add-from-predefined-carrier.js
@@ -8,9 +8,7 @@ const short = require('short-uuid');
 const {promisePool} = require('../../db');
 const sysError = require('../error');
 
-const sqlSelectCarrierByName = `SELECT * FROM voip_carriers 
-WHERE account_sid = ? 
-AND name = ?`;
+
 const sqlSelectCarrierByNameForSP = `SELECT * FROM voip_carriers 
 WHERE service_provider_sid = ? 
 AND name = ?`;
@@ -25,18 +23,20 @@ router.post('/:sid', async(req, res) => {
   const {sid } = req.params;
   let service_provider_sid;
   const {account_sid} = req.user;
+
   if (!account_sid) {
     service_provider_sid = parseServiceProviderSid(req);
+  } else {
+    service_provider_sid = req.user.service_provider_sid;
   }
+
   try {
     const [template] = await PredefinedCarrier.retrieve(sid);
     logger.debug({template}, `Retrieved template carrier for sid ${sid}`);
     if (!template) return res.sendStatus(404);
 
     /* make sure not to add the same carrier twice */
-    const [r2] = account_sid ?
-      await promisePool.query(sqlSelectCarrierByName, [account_sid, template.name]) :
-      await promisePool.query(sqlSelectCarrierByNameForSP, [service_provider_sid, template.name]);
+    const [r2] = await promisePool.query(sqlSelectCarrierByNameForSP, [service_provider_sid, template.name]);
 
     if (r2.length > 0) {
       template.name =  `${template.name}-${short.generate()}`;

--- a/lib/routes/api/speech-credentials.js
+++ b/lib/routes/api/speech-credentials.js
@@ -118,13 +118,12 @@ router.post('/', async(req, res) => {
     vendor,
   } = req.body;
   const account_sid = req.user.account_sid || req.body.account_sid;
-  let service_provider_sid;
+  const service_provider_sid = req.user.service_provider_sid || req.body.service_provider_sid;
   if (!account_sid) {
     if (!req.user.hasServiceProviderAuth && !req.user.hasAdminAuth) {
       logger.error('POST /SpeechCredentials invalid credentials');
       return res.sendStatus(403);
     }
-    service_provider_sid = parseServiceProviderSid(req);
   }
   try {
     const encrypted_credential = encryptCredential(req.body);

--- a/lib/routes/api/speech-credentials.js
+++ b/lib/routes/api/speech-credentials.js
@@ -118,7 +118,8 @@ router.post('/', async(req, res) => {
     vendor,
   } = req.body;
   const account_sid = req.user.account_sid || req.body.account_sid;
-  const service_provider_sid = req.user.service_provider_sid || req.body.service_provider_sid;
+  const service_provider_sid = req.user.service_provider_sid ||
+  req.body.service_provider_sid || parseServiceProviderSid(req);
   if (!account_sid) {
     if (!req.user.hasServiceProviderAuth && !req.user.hasAdminAuth) {
       logger.error('POST /SpeechCredentials invalid credentials');

--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -373,9 +373,16 @@ router.post('/', async(req, res) => {
 
   try {
     const email = allUsers.find((e) => e.email === payload.email);
+    const name = allUsers.find((e) => e.name === payload.name);
+
+    if (name) {
+      logger.debug({payload}, 'user with this username already exists');
+      return res.status(422).json({msg: 'user with this username already exists'});
+    }
+
     if (email) {
       logger.debug({payload}, 'user with this email already exists');
-      res.status(422).json({msg: 'user with this email already exists'});
+      return res.status(422).json({msg: 'user with this email already exists'});
     }
 
     if (decodedJwt.scope === 'admin') {


### PR DESCRIPTION
Even when POST request is going through the /Account api, service_provider_sid should always get attached to the Speech credential.

This is what is done in other resources like user, carrier, account, etc and this should act the same way. 
Here I chose to use user as the primary source of service_provider_sid since users will always be attached to SP even if they are account users (they will have both account_sid and service_provider_sid, since their account is also attached to an SP). 