### PR TITLE
Bug/speech creds get all with no sp sid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: lts/*
       - run: npm install
       - run: npm run jslint
       - run: npm test

--- a/.github/workflows/docker-publish-dbcreate.yml
+++ b/.github/workflows/docker-publish-dbcreate.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: docker build . --file Dockerfile.db-create --tag $IMAGE_NAME

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/lib/routes/api/speech-credentials.js
+++ b/lib/routes/api/speech-credentials.js
@@ -146,14 +146,22 @@ router.post('/', async(req, res) => {
  * retrieve all speech credentials for an account
  */
 router.get('/', async(req, res) => {
-  let service_provider_sid;
   const account_sid = parseAccountSid(req);
-  if (!account_sid) service_provider_sid = parseServiceProviderSid(req);
+  const service_provider_sid = parseServiceProviderSid(req) || req.user.service_provider_sid;
   const logger = req.app.locals.logger;
   try {
-    let creds = account_sid ?
-      await SpeechCredential.retrieveAll(account_sid) :
-      await SpeechCredential.retrieveAllForSP(service_provider_sid);
+    const credsAccount = await SpeechCredential.retrieveAll(account_sid);
+    const credsSP = await SpeechCredential.retrieveAllForSP(service_provider_sid);
+
+    const allCreds = [...credsAccount, ...credsSP];
+
+    // filter out creds that duplicates
+    let creds = allCreds.filter((c, i) => {
+      const dup = allCreds.find((c2, j) => {
+        return i !== j && c2.account_sid === c.account_sid;
+      });
+      return !dup;
+    });
 
     if (req.user.hasScope('account')) {
       creds = creds.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid);

--- a/lib/routes/api/speech-credentials.js
+++ b/lib/routes/api/speech-credentials.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 const assert = require('assert');
+const Account = require('../../models/account');
 const SpeechCredential = require('../../models/speech-credential');
 const sysError = require('../error');
 const {decrypt, encrypt} = require('../../utils/encrypt-decrypt');
@@ -151,18 +152,12 @@ router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
     const credsAccount = account_sid ? await SpeechCredential.retrieveAll(account_sid) : [];
-    const credsSP = await SpeechCredential.retrieveAllForSP(service_provider_sid);
+    const credsSP = service_provider_sid ?
+      await SpeechCredential.retrieveAllForSP(service_provider_sid) :
+      await SpeechCredential.retrieveAllForSP((await Account.retrieve(account_sid))[0].service_provider_sid);
 
-    const allCreds = [...credsAccount, ...credsSP];
-
-    // filter out creds that duplicates
-    let creds = allCreds.filter((c, i) => {
-      const dup = allCreds.find((c2, j) => {
-        return i !== j && JSON.stringify(c2) === JSON.stringify(c);
-      });
-      return !dup;
-    });
-
+    // filter out duplicates and discard those from other non-matching accounts
+    let creds = [...new Set([...credsAccount, ...credsSP].map((c) => JSON.stringify(c)))].map((c) => JSON.parse(c));
     if (req.user.hasScope('account')) {
       creds = creds.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid);
     }

--- a/lib/routes/api/speech-credentials.js
+++ b/lib/routes/api/speech-credentials.js
@@ -146,11 +146,11 @@ router.post('/', async(req, res) => {
  * retrieve all speech credentials for an account
  */
 router.get('/', async(req, res) => {
-  const account_sid = parseAccountSid(req);
+  const account_sid = parseAccountSid(req) || req.user.account_sid;
   const service_provider_sid = parseServiceProviderSid(req) || req.user.service_provider_sid;
   const logger = req.app.locals.logger;
   try {
-    const credsAccount = await SpeechCredential.retrieveAll(account_sid);
+    const credsAccount = account_sid ? await SpeechCredential.retrieveAll(account_sid) : [];
     const credsSP = await SpeechCredential.retrieveAllForSP(service_provider_sid);
 
     const allCreds = [...credsAccount, ...credsSP];
@@ -158,7 +158,7 @@ router.get('/', async(req, res) => {
     // filter out creds that duplicates
     let creds = allCreds.filter((c, i) => {
       const dup = allCreds.find((c2, j) => {
-        return i !== j && c2.account_sid === c.account_sid;
+        return i !== j && JSON.stringify(c2) === JSON.stringify(c);
       });
       return !dup;
     });

--- a/test/service-providers.js
+++ b/test/service-providers.js
@@ -86,7 +86,7 @@ test('service provider tests', async(t) => {
       auth: authAdmin,
       json: true,
     });
-    console.log(JSON.stringify(result));
+    //console.log(JSON.stringify(result));
     t.ok(result.length === 2 , 'successfully queried all service providers');
 
     /* query one service providers */


### PR DESCRIPTION
@davehorton my idea for returning the list where all Speech credentials are returned regardless if they have service_provider_sid or not. My idea here was very simple, to fetch both account and SP speech combine arrays and remove duplicates. But this is not working. I am not sure I understand why.

I haven't fixed the tests because the solution is not yet working. 

To be tested with this webapp PR: https://github.com/jambonz/jambonz-webapp/pull/186

Also, how did you test with not recreating the DB, but using already created one? I always run "npm run integration-test" this way the db is always fresh.