### PR TITLE
Add check for users to delete function

### DIFF
--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -12,7 +12,7 @@ const {hasServiceProviderPermissions, parseServiceProviderSid} = require('./util
 const sysError = require('../error');
 const decorate = require('./decorate');
 const preconditions = {
-  'delete': noActiveAccountsorUsers
+  'delete': noActiveAccountsOrUsers
 };
 const sqlDeleteSipGateways = `DELETE from sip_gateways 
 WHERE voip_carrier_sid IN (
@@ -59,7 +59,7 @@ function validateUpdate(req) {
 }
 
 /* can not delete a service provider if it has any active accounts */
-async function noActiveAccountsorUsers(req, sid) {
+async function noActiveAccountsOrUsers(req, sid) {
   if (!req.user.hasAdminAuth) {
     throw new DbErrorForbidden('only admin users can delete a service provider');
   }

--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -12,7 +12,7 @@ const {hasServiceProviderPermissions, parseServiceProviderSid} = require('./util
 const sysError = require('../error');
 const decorate = require('./decorate');
 const preconditions = {
-  'delete': noActiveAccounts
+  'delete': noActiveAccountsorUsers
 };
 const sqlDeleteSipGateways = `DELETE from sip_gateways 
 WHERE voip_carrier_sid IN (
@@ -59,12 +59,20 @@ function validateUpdate(req) {
 }
 
 /* can not delete a service provider if it has any active accounts */
-async function noActiveAccounts(req, sid) {
+async function noActiveAccountsorUsers(req, sid) {
   if (!req.user.hasAdminAuth) {
     throw new DbErrorForbidden('only admin users can delete a service provider');
   }
   const activeAccounts = await ServiceProvider.getForeignKeyReferences('accounts.service_provider_sid', sid);
+  const activeUsers = await ServiceProvider.getForeignKeyReferences('users.service_provider_sid', sid);
+  if (activeAccounts > 0 && activeUsers > 0) throw new DbErrorUnprocessableRequest(
+    'cannot delete service provider with active accounts or users'
+  );
+
   if (activeAccounts > 0) throw new DbErrorUnprocessableRequest('cannot delete service provider with active accounts');
+  if (activeUsers > 0) throw new DbErrorUnprocessableRequest(
+    'cannot delete service provider with active service provider level users'
+  );
 
   /* ok we can delete -- no active accounts.  remove carriers and speech credentials */
   await promisePool.execute('DELETE from speech_credentials WHERE service_provider_sid = ?', [sid]);

--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -424,7 +424,8 @@ router.delete('/:user_sid', async(req, res) => {
   const user = await User.retrieve(user_sid);
 
   try {
-    if (decodedJwt.scope === 'admin' && activeAdminUsers.length === 1) {
+    if (decodedJwt.scope === 'admin' && !user.account_sid && !user.service_provider_sid &&
+     activeAdminUsers.length === 1) {
       throw new Error('cannot delete this admin user - there are no other active admin users');
     }
 


### PR DESCRIPTION
This PR fixed check for active users and accounts (throws an error if users associated with SP exist when deleting SP).

And fixes the active admin user check, that was throwing this error when deleting another user.