### PR TITLE
Update node to node:18.14.0-alpine3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:18-alpine3.16 as base
+FROM --platform=linux/amd64 node:18.14.0-alpine3.16 as base
 
 RUN apk --update --no-cache add --virtual .builds-deps build-base python3
 


### PR DESCRIPTION
This PR upgrades node base image to node:18.14.0-alpine3.16

This fixes:
Critical vulnerability:
CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')

High vulnerability:
CWE-416: Double Free
CWE-416: Use After Free