### PR TITLE
add ENCRYPTION_SECRET variable

### DIFF
--- a/lib/utils/encrypt-decrypt.js
+++ b/lib/utils/encrypt-decrypt.js
@@ -2,9 +2,9 @@ const crypto = require('crypto');
 const algorithm = process.env.LEGACY_CRYPTO ? 'aes-256-ctr' : 'aes-256-cbc';
 const iv = crypto.randomBytes(16);
 const secretKey = crypto.createHash('sha256')
-  .update(String(process.env.JWT_SECRET))
+  .update(process.env.ENCRYPTION_SECRET || process.env.JWT_SECRET)
   .digest('base64')
-  .substr(0, 32);
+  .substring(0, 32);
 
 const encrypt = (text) => {
   const cipher = crypto.createCipheriv(algorithm, secretKey, iv);


### PR DESCRIPTION
At this moment "JWT_SECRET" is being used to encrypt/decrypt speech credentials and from my point of view this is misleading since it should be used just for the authentication. I'm suggesting to add a new variable called "ENCRYPTION_SECRET" for that. The same thing i'm planning to add for the feature-server to keep it in sync if this PR is accepted.