### PR TITLE
fix request validation for resource fetched

### DIFF
--- a/db/seed-integration-test.sql
+++ b/db/seed-integration-test.sql
@@ -27,6 +27,15 @@ values ('2708b1b3-2736-40ea-b502-c53d8396247f', 'default service provider', 'sip
 insert into accounts (account_sid, service_provider_sid, name, webhook_secret) 
 values ('9351f46a-678c-43f5-b8a6-d4eb58d131af','2708b1b3-2736-40ea-b502-c53d8396247f', 'default account', 'wh_secret_cJqgtMDPzDhhnjmaJH6Mtk');
 
+-- create account level api key
+insert into api_keys (api_key_sid, token, service_provider_sid) 
+values ('3f35518f-5a0d-4c2e-90a5-2407bb3b36f0', '38700987-c7a4-4685-a5bb-af378f9734da', '9351f46a-678c-43f5-b8a6-d4eb58d131af');
+
+-- create SP level api key
+insert into api_keys (api_key_sid, token, account_sid) 
+values ('3f35518f-5a0d-4c2e-90a5-2407bb3b36f0', '38700987-c7a4-4685-a5bb-af378f9734ds', '2708b1b3-2736-40ea-b502-c53d8396247f');
+
+
 -- create two applications
 insert into webhooks(webhook_sid, url, method)
 values 

--- a/lib/routes/api/accounts.js
+++ b/lib/routes/api/accounts.js
@@ -45,7 +45,7 @@ const stripPort = (hostport) => {
   return hostport;
 };
 
-const validateUpdateForCarrier = async(req) => {
+const validateRequest = async(req) => {
   try {
     const account_sid = parseAccountSid(req);
 
@@ -58,7 +58,7 @@ const validateUpdateForCarrier = async(req) => {
         return;
       }
 
-      throw new DbErrorForbidden('insufficient permissions to update account');
+      throw new DbErrorForbidden('insufficient permissions');
     }
 
     if (req.user.hasScope('service_provider')) {
@@ -70,7 +70,7 @@ const validateUpdateForCarrier = async(req) => {
         return;
       }
 
-      throw new DbErrorForbidden('insufficient permissions to update account');
+      throw new DbErrorForbidden('insufficient permissions');
     }
   } catch (error) {
     throw error;
@@ -84,6 +84,7 @@ router.use('/:sid/Charges', hasAccountPermissions, require('./charges'));
 router.use('/:sid/SipRealms', hasAccountPermissions, require('./sip-realm'));
 router.use('/:sid/PredefinedCarriers', hasAccountPermissions, require('./add-from-predefined-carrier'));
 router.use('/:sid/Limits', hasAccountPermissions, require('./limits'));
+
 router.get('/:sid/Applications', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
@@ -107,7 +108,7 @@ router.get('/:sid/VoipCarriers', async(req, res) => {
 router.put('/:sid/VoipCarriers/:voip_carrier_sid', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
-    await validateUpdateForCarrier(req);
+    await validateRequest(req);
     const rowsAffected = await VoipCarrier.update(req.params.voip_carrier_sid, req.body);
     if (rowsAffected === 0) {
       return res.sendStatus(404);
@@ -122,6 +123,7 @@ router.post('/:sid/VoipCarriers', async(req, res) => {
   const logger = req.app.locals.logger;
   const payload = req.body;
   try {
+    validateRequest(req);
     const account_sid = parseAccountSid(req);
     logger.debug({payload}, 'POST /:sid/VoipCarriers');
     const uuid = await VoipCarrier.make({
@@ -394,6 +396,7 @@ async function validateDelete(req, sid) {
 router.post('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRequest(req);
     const secret = `wh_secret_${translator.generate()}`;
     await validateAdd(req);
 
@@ -431,6 +434,7 @@ router.get('/', async(req, res) => {
 router.get('/:sid', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRequest(req);
     const service_provider_sid = req.user.hasServiceProviderAuth ? req.user.service_provider_sid : null;
     const results = await Account.retrieve(req.params.sid, service_provider_sid);
     if (results.length === 0) return res.status(404).end();
@@ -444,6 +448,7 @@ router.get('/:sid', async(req, res) => {
 router.get('/:sid/WebhookSecret', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRequest(req);
     const service_provider_sid = req.user.hasServiceProviderAuth ? req.user.service_provider_sid : null;
     const results = await Account.retrieve(req.params.sid, service_provider_sid);
     if (results.length === 0) return res.status(404).end();
@@ -463,6 +468,7 @@ router.get('/:sid/WebhookSecret', async(req, res) => {
 router.post('/:sid/SubspaceTeleport', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRequest(req);
     const service_provider_sid = req.user.hasServiceProviderAuth ? req.user.service_provider_sid : null;
     const results = await Account.retrieve(req.params.sid, service_provider_sid);
     if (results.length === 0) return res.status(404).end();
@@ -495,6 +501,7 @@ router.post('/:sid/SubspaceTeleport', async(req, res) => {
 router.delete('/:sid/SubspaceTeleport', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRequest(req);
     const service_provider_sid = req.user.hasServiceProviderAuth ? req.user.service_provider_sid : null;
     const results = await Account.retrieve(req.params.sid, service_provider_sid);
     if (results.length === 0) return res.status(404).end();
@@ -582,6 +589,7 @@ router.delete('/:sid', async(req, res) => {
     WHERE voip_carrier_sid IN
     (SELECT voip_carrier_sid from voip_carriers where account_sid = ?)`;
   try {
+    await validateRequest(req);
     await validateDelete(req, sid);
 
     const [account] = await promisePool.query('SELECT * FROM accounts WHERE account_sid = ?', sid);
@@ -649,6 +657,7 @@ account_subscriptions WHERE account_sid = ?)
 router.get('/:sid/ApiKeys', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRequest(req);
     const results = await ApiKey.retrieveAll(req.params.sid);
     res.status(200).json(results);
     updateLastUsed(logger, req.params.sid, req).catch((err) => {});
@@ -670,6 +679,7 @@ router.post('/:sid/Calls', async(req, res) => {
     res.status(480).json({msg: 'no available feature servers at this time'});
   } else {
     try {
+      await validateRequest(req);
       await validateCreateCall(logger, sid, req);
       updateLastUsed(logger, sid, req).catch((err) => {});
       request({
@@ -702,6 +712,7 @@ router.get('/:sid/Calls', async(req, res) => {
   const {logger, listCalls} = req.app.locals;
 
   try {
+    await validateRequest(req);
     const calls = await listCalls(accountSid);
     logger.debug(`retrieved ${calls.length} calls for account sid ${accountSid}`);
     res.status(200).json(coerceNumbers(snakeCase(calls)));
@@ -720,6 +731,7 @@ router.get('/:sid/Calls/:callSid', async(req, res) => {
   const {logger, retrieveCall} = req.app.locals;
 
   try {
+    await validateRequest(req);
     const callInfo = await retrieveCall(accountSid, callSid);
     if (callInfo) {
       logger.debug(callInfo, `retrieved call info for call sid ${callSid}`);
@@ -744,6 +756,7 @@ router.delete('/:sid/Calls/:callSid', async(req, res) => {
   const {logger, deleteCall} = req.app.locals;
 
   try {
+    await validateRequest(req);
     const result = await deleteCall(accountSid, callSid);
     if (result) {
       logger.debug(`successfully deleted call ${callSid}`);
@@ -768,6 +781,7 @@ const updateCall = async(req, res) => {
   const {logger, retrieveCall} = req.app.locals;
 
   try {
+    await validateRequest(req);
     validateUpdateCall(req.body);
     const call = await retrieveCall(accountSid, callSid);
     if (call) {
@@ -792,9 +806,11 @@ const updateCall = async(req, res) => {
 
 /** leaving for legacy purposes, this should have been (and now is) a PUT */
 router.post('/:sid/Calls/:callSid', async(req, res) => {
+  await validateRequest(req);
   await updateCall(req, res);
 });
 router.put('/:sid/Calls/:callSid', async(req, res) => {
+  await validateRequest(req);
   await updateCall(req, res);
 });
 
@@ -807,6 +823,7 @@ router.post('/:sid/Messages', async(req, res) => {
   try {
     const account_sid = parseAccountSid(req);
     const setName = `${(process.env.JAMBONES_CLUSTER_ID || 'default')}:active-fs`;
+    await validateRequest(req);
     const serviceUrl = await getFsUrl(logger, retrieveSet, setName);
     if (!serviceUrl) res.json({msg: 'no available feature servers at this time'}).status(480);
     await validateCreateMessage(logger, account_sid, req);

--- a/lib/routes/api/phone-numbers.js
+++ b/lib/routes/api/phone-numbers.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const {DbErrorUnprocessableRequest, DbErrorBadRequest} = require('../../utils/errors');
 const PhoneNumber = require('../../models/phone-number');
 const VoipCarrier = require('../../models/voip-carrier');
+const {promisePool} = require('../../db');
 const decorate = require('./decorate');
 const {e164} = require('../../utils/phone-number-utils');
 const preconditions = {
@@ -74,7 +75,9 @@ decorate(router, PhoneNumber, ['add', 'update', 'delete'], preconditions);
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
-    const results = await PhoneNumber.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null);
+    const results = req.user.hasAdminAuth ?
+      await PhoneNumber.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null) :
+      await PhoneNumber.retrieveAllForSP(req.user.service_provider_sid);
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
@@ -88,6 +91,14 @@ router.get('/:sid', async(req, res) => {
     const account_sid = req.user.hasAccountAuth ? req.user.account_sid : null;
     const results = await PhoneNumber.retrieve(req.params.sid, account_sid);
     if (results.length === 0) return res.status(404).end();
+    if (req.user.hasServiceProviderAuth && results.length === 1) {
+      const account_sid = results[0].account_sid;
+      const [r] = await promisePool.execute(
+        'SELECT service_provider_sid from accounts WHERE account_sid = ?', [account_sid]);
+      if (r[0].service_provider_sid === !req.user.service_provider_sid) {
+        throw new DbErrorBadRequest('insufficient privileges');
+      }
+    }
     return res.status(200).json(results[0]);
   }
   catch (err) {

--- a/lib/routes/api/phone-numbers.js
+++ b/lib/routes/api/phone-numbers.js
@@ -95,7 +95,7 @@ router.get('/:sid', async(req, res) => {
       const account_sid = results[0].account_sid;
       const [r] = await promisePool.execute(
         'SELECT service_provider_sid from accounts WHERE account_sid = ?', [account_sid]);
-      if (r[0].service_provider_sid === !req.user.service_provider_sid) {
+      if (r.length === 1 && r[0].service_provider_sid === !req.user.service_provider_sid) {
         throw new DbErrorBadRequest('insufficient privileges');
       }
     }

--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -8,7 +8,7 @@ const VoipCarrier = require('../../models/voip-carrier');
 const Application = require('../../models/application');
 const PhoneNumber = require('../../models/phone-number');
 const ApiKey = require('../../models/api-key');
-const {hasServiceProviderPermissions, parseServiceProviderSid} = require('./utils');
+const {hasServiceProviderPermissions, parseServiceProviderSid, hasAccountPermissions} = require('./utils');
 const sysError = require('../error');
 const decorate = require('./decorate');
 const preconditions = {
@@ -47,13 +47,13 @@ async function validateRetrieve(req) {
     }
 
     if (req.user.hasScope('account')) {
-      /* allow account users to retrieve service provider data from parent SP */
+    /* allow account users to retrieve service provider data from parent SP */
       const sid = req.user.account_sid;
       const [r] = await promisePool.execute('SELECT service_provider_sid from accounts WHERE account_sid = ?', [sid]);
-      if (r.length === 1 && r[0].service_provider_sid === req.user.service_provider_sid) return;
+      if (r.length !== 0 && r[0].service_provider_sid === req.user.service_provider_sid) return;
     }
 
-    throw new DbErrorForbidden('insufficient permissions to update service provider');
+    throw new DbErrorForbidden('insufficient permissions');
   } catch (error) {
     throw error;
   }
@@ -105,9 +105,10 @@ decorate(router, ServiceProvider, ['delete'], preconditions);
 
 router.use('/:sid/RecentCalls', hasServiceProviderPermissions, require('./recent-calls'));
 router.use('/:sid/Alerts', hasServiceProviderPermissions, require('./alerts'));
-router.use('/:sid/SpeechCredentials', require('./speech-credentials'));
+router.use('/:sid/SpeechCredentials', hasAccountPermissions, require('./speech-credentials'));
 router.use('/:sid/Limits', hasServiceProviderPermissions, require('./limits'));
 router.use('/:sid/PredefinedCarriers', hasServiceProviderPermissions, require('./add-from-predefined-carrier'));
+
 router.get('/:sid/Accounts', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
@@ -249,6 +250,7 @@ router.get('/', async(req, res) => {
 router.get('/:sid', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
+    await validateRetrieve(req);
     const results = await ServiceProvider.retrieve(req.params.sid);
     if (results.length === 0) return res.status(404).end();
     return res.status(200).json(results[0]);

--- a/lib/routes/api/utils.js
+++ b/lib/routes/api/utils.js
@@ -164,20 +164,28 @@ const parseAccountSid = (req) => {
   }
 };
 
-const hasAccountPermissions = (req, res, next) => {
+const hasAccountPermissions = async(req, res, next) => {
   try {
     if (req.user.hasScope('admin')) {
       return next();
     }
 
     if (req.user.hasScope('service_provider')) {
-      return next();
+      const service_provider_sid = parseServiceProviderSid(req);
+      if (service_provider_sid === req.user.service_provider_sid) return next();
     }
 
     if (req.user.hasScope('account')) {
       const account_sid = parseAccountSid(req);
-      if (account_sid === req.user.account_sid) {
-        return next();
+      const service_provider_sid = parseServiceProviderSid(req);
+
+      if (service_provider_sid || account_sid) {
+        const [r] = await Account.retrieveAll(service_provider_sid, account_sid);
+
+        if (r.length > 0 && r.find((acc) => acc.account_sid === req.user.account_sid &&
+        acc.service_provider_sid === req.user.service_provider_sid)) {
+          return next();
+        }
       }
     }
 

--- a/lib/routes/api/voip-carriers.js
+++ b/lib/routes/api/voip-carriers.js
@@ -73,7 +73,9 @@ decorate(router, VoipCarrier, ['add', 'update', 'delete'], preconditions);
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
-    const results = await VoipCarrier.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null);
+    const results = req.user.hasAdminAuth ?
+      await VoipCarrier.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null) :
+      await VoipCarrier.retrieveAllForSP(req.user.service_provider_sid);
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
@@ -87,6 +89,15 @@ router.get('/:sid', async(req, res) => {
     const account_sid = req.user.hasAccountAuth ? req.user.account_sid : null;
     const results = await VoipCarrier.retrieve(req.params.sid, account_sid);
     if (results.length === 0) return res.status(404).end();
+    if (req.user.hasServiceProviderAuth && results.length === 1) {
+      const account_sid = results[0].account_sid;
+      const [r] = await promisePool.execute(
+        'SELECT service_provider_sid from accounts WHERE account_sid = ?', [account_sid]);
+      console.log('Voip', r);
+      if (r[0].service_provider_sid === !req.user.service_provider_sid) {
+        throw new DbErrorBadRequest('insufficient privileges');
+      }
+    }
     return res.status(200).json(results[0]);
   }
   catch (err) {

--- a/lib/routes/api/voip-carriers.js
+++ b/lib/routes/api/voip-carriers.js
@@ -93,8 +93,7 @@ router.get('/:sid', async(req, res) => {
       const account_sid = results[0].account_sid;
       const [r] = await promisePool.execute(
         'SELECT service_provider_sid from accounts WHERE account_sid = ?', [account_sid]);
-      console.log('Voip', r);
-      if (r[0].service_provider_sid === !req.user.service_provider_sid) {
+      if (r.length === 1 && r[0].service_provider_sid === !req.user.service_provider_sid) {
         throw new DbErrorBadRequest('insufficient privileges');
       }
     }

--- a/test/accounts.js
+++ b/test/accounts.js
@@ -1,6 +1,10 @@
 const test = require('tape') ;
 const ADMIN_TOKEN = '38700987-c7a4-4685-a5bb-af378f9734de';
+const ACCOUNT_TOKEN = '38700987-c7a4-4685-a5bb-af378f9734da';
+const SP_TOKEN = '38700987-c7a4-4685-a5bb-af378f9734ds';
 const authAdmin = {bearer: ADMIN_TOKEN};
+const authAccount = {bearer: ACCOUNT_TOKEN};
+const authSP = {bearer: SP_TOKEN};
 const request = require('request-promise-native').defaults({
   baseUrl: 'http://127.0.0.1:3000/v1'
 });
@@ -267,6 +271,14 @@ test('account tests', async(t) => {
     await deleteObjectBySid(request, '/VoipCarriers', voip_carrier_sid);
     await deleteObjectBySid(request, '/ServiceProviders', service_provider_sid);
     //t.end();
+
+    /* query all limits for an account */
+    result = await request.get(`/Accounts/some-sid`, {
+      auth: authAccount,
+      json: true,
+    });
+    console.log(result);
+    t.ok(result.statusCode, 'some-sid will return insufficient permissions');
   }
   catch (err) {
     console.error(err);


### PR DESCRIPTION
@davehorton I started working on this validation for each resource, right now I think I covered most of it. Since we already had some validation separated for most of the calls, I just continued with that approach. But maybe in the future, this will need a small redesign to streamline some things.

E.g these were not limited to foreign account/SP users. We were only checking the scope in cases.
• GET /v1/Accounts/:sid
• GET /v1/Accounts/:sid/VoipCarriers
• GET /v1/Accounts/:sid/ApiKeys
• GET /v1/Accounts/:sid/Applications
• GET /v1/Accounts/:sid/WebhookSecret
• POST /v1/Accounts/:sid/SubspaceTeleport
• GET /v1/Accounts/:sid/Calls
• GET /v1/Accounts/:sid/calls/:call_sid
• GET /v1/Accounts/:sid/RecentCalls?page=1&count=25
• GET /v1/Accounts/:sid/SpeechCredentials
• GET /v1/Accounts/:sid/Alerts?page=1&count=25
• GET /v1/Accounts/:sid/Charges
• GET /v1/ServiceProviders/:sid
• GET /v1/ServiceProviders/:sid/SpeechCredentials
• GET /v1/ServiceProviders/:sid/VoipCarriers
• GET /v1/SipGateways?voip_carrier_sid=:sid
• GET /v1/ServiceProviders/:sid/SpeechCredentials/:speech_credential_sid
• GET /v1/ServiceProviders/:sid/SpeechCredentials/:speech_credential_sid/test
• DELETE /v1/Applications/:sid
• PUT /v1/Applications/:sid

I got a bit stuck with the test writing, I was trying to seed the DB with an account/SP level api tokens, so I can write some tests to validate some calls.