### PR TITLE
Improved invalidation of JWT in redis

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,5 @@
 const assert = require('assert');
-const opts = Object.assign({
-  timestamp: () => {
-    return `, "time": "${new Date().toISOString()}"`;
-  }
-}, {
-  level: process.env.JAMBONES_LOGLEVEL || 'info'
-});
-const logger = require('pino')(opts);
+const logger = require('./lib/logger');
 const express = require('express');
 const app = express();
 const helmet = require('helmet');

--- a/app.js
+++ b/app.js
@@ -44,10 +44,7 @@ const {
   addKey,
   retrieveKey,
   deleteKey,
-} = require('@jambonz/realtimedb-helpers')({
-  host: process.env.JAMBONES_REDIS_HOST,
-  port: process.env.JAMBONES_REDIS_PORT || 6379
-}, logger);
+} = require('./lib/helpers/realtimedb-helpers');
 const {
   getTtsVoices
 } = require('@jambonz/speech-utils')({

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,41 +1,42 @@
 const Strategy = require('passport-http-bearer').Strategy;
 const {getMysqlConnection} = require('../db');
-const {hashString} = require('../utils/password-utils');
 const debug = require('debug')('jambonz:api-server');
+const {cacheClient} = require('../helpers');
 const jwt = require('jsonwebtoken');
 const sql = `
   SELECT *
   FROM api_keys
   WHERE api_keys.token = ?`;
 
-function makeStrategy(logger, retrieveKey) {
+function makeStrategy(logger) {
   return new Strategy(
     async function(token, done) {
-      //logger.debug(`validating with token ${token}`);
       jwt.verify(token, process.env.JWT_SECRET, async(err, decoded) => {
         if (err) {
           if (err.name === 'TokenExpiredError') {
             logger.debug('jwt expired');
             return done(null, false);
           }
-          /* its not a jwt obtained through login, check api leys */
+          /* its not a jwt obtained through login, check api keys */
           checkApiTokens(logger, token, done);
         }
         else {
-          /* validated -- make sure it is not on blacklist */
           try {
-            const s = `jwt:${hashString(token)}`;
-            const result = await retrieveKey(s);
-            if (result) {
-              debug(`result from searching for ${s}: ${result}`);
+            const {user_sid} = decoded;
+            /* Valid jwt tokens are stored in redis by hashed user_id */
+            const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+            const result = await cacheClient.get(redisKey);
+            if (result === null) {
+              debug(`result from searching for ${redisKey}: ${result}`);
               logger.info('jwt invalidated after logout');
               return done(null, false);
             }
-          } catch (err) {
+          } catch (error) {
             debug(err);
-            logger.info({err}, 'Error checking blacklist for jwt');
+            logger.info({err}, 'Error checking redis for jwt');
           }
-          const {user_sid, service_provider_sid, account_sid, email, name, scope, permissions} = decoded;
+          const { user_sid, service_provider_sid, account_sid, email, name, scope, permissions } = decoded;
+
           const user = {
             service_provider_sid,
             account_sid,

--- a/lib/helpers/cache-client.js
+++ b/lib/helpers/cache-client.js
@@ -68,13 +68,11 @@ class CacheClient {
     }
 
     switch (type) {
-      case 'jwt':
-        return `jwt:${hashString(key)}${suffix}`;
-
       case 'reset-link':
         return `reset-link:${key}`;
+      case 'jwt':
       default:
-        break;
+        return `jwt:${hashString(key)}${suffix}`;
     }
   }
 }

--- a/lib/helpers/cache-client.js
+++ b/lib/helpers/cache-client.js
@@ -1,0 +1,84 @@
+const {
+  addKey: addKeyRedis,
+  deleteKey: deleteKeyRedis,
+  retrieveKey: retrieveKeyRedis,
+} = require('./realtimedb-helpers');
+const { hashString } = require('../utils/password-utils');
+const logger = require('../logger');
+
+class CacheClient {
+  constructor() { }
+
+  async set(params) {
+    const {
+      redisKey,
+      value = '1',
+      time = 3600,
+    } = params || {};
+
+    try {
+      await addKeyRedis(redisKey, value, time);
+
+    } catch (err) {
+      logger.error('CacheClient.get set', {
+        error: {
+          message: err.message,
+          name: err.name
+        },
+        ...params
+      });
+    }
+  }
+
+  async get(redisKey) {
+    try {
+      const result = await retrieveKeyRedis(redisKey);
+      return result;
+    } catch (err) {
+      logger.error('CacheClient.get error', {
+        error: {
+          message: err.message,
+          name: err.name
+        },
+        redisKey
+      });
+    }
+  }
+
+
+  async delete(key) {
+    try {
+      await deleteKeyRedis(key);
+      logger.debug('CacheClient.delete key from redis', { key });
+    } catch (err) {
+      logger.error('CacheClient.delete error', {
+        error: {
+          message: err.message,
+          name: err.name
+        },
+        key
+      });
+    }
+  }
+
+  generateRedisKey(type, key, version) {
+    let suffix = '';
+    if (version) {
+      suffix = `:version:${version}`;
+    }
+
+    switch (type) {
+      case 'jwt':
+        return `jwt:${hashString(key)}${suffix}`;
+
+      case 'reset-link':
+        return `reset-link:${key}`;
+      default:
+        break;
+    }
+  }
+}
+
+const cacheClient = new CacheClient();
+
+module.exports = { cacheClient };

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require('./cache-client'),
+  ...require('./realtimedb-helpers'),
+};

--- a/lib/helpers/realtimedb-helpers.js
+++ b/lib/helpers/realtimedb-helpers.js
@@ -1,0 +1,28 @@
+const logger = require('../logger');
+
+const {
+  retrieveCall,
+  deleteCall,
+  listCalls,
+  purgeCalls,
+  retrieveSet,
+  addKey,
+  retrieveKey,
+  deleteKey,
+  client: redisClient,
+} = require('@jambonz/realtimedb-helpers')({
+  host: process.env.JAMBONES_REDIS_HOST || 'localhost',
+  port: process.env.JAMBONES_REDIS_PORT || 6379
+}, logger);
+
+module.exports = {
+  retrieveCall,
+  deleteCall,
+  listCalls,
+  purgeCalls,
+  retrieveSet,
+  addKey,
+  retrieveKey,
+  deleteKey,
+  redisClient,
+};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,11 @@
+const opts = Object.assign({
+  timestamp: () => {
+    return `, "time": "${new Date().toISOString()}"`;
+  }
+}, {
+  level: process.env.JAMBONES_LOGLEVEL || 'info'
+});
+
+const logger = require('pino')(opts);
+
+module.exports = logger;

--- a/lib/routes/api/change-password.js
+++ b/lib/routes/api/change-password.js
@@ -1,15 +1,15 @@
 const router = require('express').Router();
-//const debug = require('debug')('jambonz:api-server');
 const {DbErrorBadRequest} = require('../../utils/errors');
 const {generateHashedPassword, verifyPassword} = require('../../utils/password-utils');
 const {promisePool} = require('../../db');
+const {cacheClient} = require('../../helpers');
 const sysError = require('../error');
 const sqlUpdatePassword = `UPDATE users 
 SET hashed_password= ? 
 WHERE user_sid = ?`;
 
 router.post('/', async(req, res) => {
-  const {logger, retrieveKey, deleteKey} = req.app.locals;
+  const {logger} = req.app.locals;
   const {user_sid} = req.user;
   const {old_password, new_password} = req.body;
   try {
@@ -26,10 +26,10 @@ router.post('/', async(req, res) => {
 
       const isCorrect = await verifyPassword(r[0].hashed_password, old_password);
       if (!isCorrect) {
-        const key = `reset-link:${old_password}`;
-        const user_sid = await retrieveKey(key);
+        const key = cacheClient.generateRedisKey('reset-link', old_password);
+        const user_sid = await cacheClient.get(key);
         if (!user_sid) throw new DbErrorBadRequest('old_password is incorrect');
-        await deleteKey(key);
+        await cacheClient.delete(key);
       }
     }
 
@@ -42,6 +42,9 @@ router.post('/', async(req, res) => {
     sysError(logger, res, err);
     return;
   }
+
+  const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+  await cacheClient.delete(redisKey);
 });
 
 module.exports = router;

--- a/lib/routes/api/forgot-password.js
+++ b/lib/routes/api/forgot-password.js
@@ -4,6 +4,7 @@ const short = require('short-uuid');
 const translator = short();
 const {validateEmail, emailSimpleText} = require('../../utils/email-utils');
 const {promisePool} = require('../../db');
+const {cacheClient} = require('../../helpers');
 const sysError = require('../error');
 const sql = `SELECT * from users user 
 LEFT JOIN accounts AS acc 
@@ -45,6 +46,7 @@ function createResetEmailText(link) {
 router.post('/', async(req, res) => {
   const {logger, addKey} = req.app.locals;
   const {email} = req.body;
+  const {user_sid} = req.user;
   let obj;
   try {
     if (!email || !validateEmail(email)) {
@@ -73,10 +75,14 @@ router.post('/', async(req, res) => {
   else {
     /* generate a link for this user to reset, send email */
     const link = translator.generate();
-    addKey(`reset-link:${link}`, obj.user.user_sid, 3600)
+    const redisKey = cacheClient.generateRedisKey('reset-link', link);
+    addKey(redisKey, obj.user.user_sid, 3600)
       .catch((err) => logger.error({err}, 'Error adding reset link to redis'));
     emailSimpleText(logger, email, 'Reset password request', createResetEmailText(link));
   }
+
+  const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+  await cacheClient.delete(redisKey);
 });
 
 module.exports = router;

--- a/lib/routes/api/login.js
+++ b/lib/routes/api/login.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const jwt = require('jsonwebtoken');
 const {verifyPassword} = require('../../utils/password-utils');
 const {promisePool} = require('../../db');
+const {cacheClient} = require('../../helpers');
 const Account = require('../../models/account');
 const ServiceProvider = require('../../models/service-provider');
 const sysError = require('../error');
@@ -71,12 +72,22 @@ router.post('/', async(req, res) => {
       }),
       user_sid: obj.user_sid
     };
+
+    const expiresIn = parseInt(process.env.JWT_EXPIRES_IN || 60) * 60;
     const token = jwt.sign(
       payload,
       process.env.JWT_SECRET,
-      { expiresIn: parseInt(process.env.JWT_EXPIRES_IN || 60) * 60 }
+      { expiresIn }
     );
     res.json({token, ...obj});
+
+    /* Store jwt based on user_id after successful login */
+    await cacheClient.set({
+      redisKey: cacheClient.generateRedisKey('jwt', obj.user_sid, 'v2'),
+      value: token,
+      time: expiresIn,
+    });
+
   } catch (err) {
     sysError(logger, res, err);
   }

--- a/lib/routes/api/logout.js
+++ b/lib/routes/api/logout.js
@@ -1,19 +1,18 @@
 const router = require('express').Router();
 const debug = require('debug')('jambonz:api-server');
-const {hashString} = require('../../utils/password-utils');
+const {cacheClient} = require('../../helpers');
 const sysError = require('../error');
 
 router.post('/', async(req, res) => {
-  const {logger, addKey} = req.app.locals;
-  const {jwt} = req.user;
+  const {logger} = req.app.locals;
+  const {user_sid} = req.user;
 
-  debug(`adding jwt to blacklist: ${jwt}`);
+  debug(`logout user and invalidate jwt token for user: ${user_sid}`);
 
   try {
-    /* add key to blacklist */
-    const s = `jwt:${hashString(jwt)}`;
-    const result = await addKey(s, '1', 3600);
-    debug(`result from adding ${s}: ${result}`);
+    const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+    await cacheClient.delete(redisKey);
+
     res.sendStatus(204);
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/register.js
+++ b/lib/routes/api/register.js
@@ -4,6 +4,7 @@ const {DbErrorBadRequest, DbErrorUnprocessableRequest} = require('../../utils/er
 const {promisePool} = require('../../db');
 const {doGithubAuth, doGoogleAuth, doLocalAuth} = require('../../utils/oauth-utils');
 const {validateEmail} = require('../../utils/email-utils');
+const {cacheClient} = require('../../helpers');
 const { v4: uuid } = require('uuid');
 const short = require('short-uuid');
 const translator = short();
@@ -338,16 +339,19 @@ router.post('/', async(req, res) => {
         /* deactivate the old/replaced user */
         const [r] = await promisePool.execute('DELETE FROM users WHERE user_sid = ?', [user_sid]);
         logger.debug({r}, 'register - removed old user');
+        const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+        await cacheClient.delete(redisKey);
       }
     }
 
+    const expiresIn = parseInt(process.env.JWT_EXPIRES_IN || 60) * 60 ;
     // generate a json web token for this user
     const token = jwt.sign({
       user_sid: userProfile.user_sid,
       account_sid: userProfile.account_sid,
       email: userProfile.email,
       name: userProfile.name
-    }, process.env.JWT_SECRET, { expiresIn: parseInt(process.env.JWT_EXPIRES_IN || 60) * 60 });
+    }, process.env.JWT_SECRET, { expiresIn });
 
     logger.debug({
       user_sid: userProfile.user_sid,
@@ -355,6 +359,13 @@ router.post('/', async(req, res) => {
     }, 'generated jwt');
 
     res.json({jwt: token, ...userProfile});
+
+    /* Store jwt based on user_id after successful login */
+    await cacheClient.set({
+      redisKey: cacheClient.generateRedisKey('jwt', userProfile.user_sid, 'v2'),
+      value: token,
+      time: expiresIn,
+    });
 
   } catch (err) {
     debug(err, 'Error');

--- a/lib/routes/api/signin.js
+++ b/lib/routes/api/signin.js
@@ -3,6 +3,7 @@ const router = require('express').Router();
 const {DbErrorBadRequest} = require('../../utils/errors');
 const {promisePool} = require('../../db');
 const {verifyPassword} = require('../../utils/password-utils');
+const {cacheClient} = require('../../helpers');
 const jwt = require('jsonwebtoken');
 const sysError = require('../error');
 
@@ -64,11 +65,12 @@ router.post('/', async(req, res) => {
       pristine: false
     });
 
+    const expiresIn = parseInt(process.env.JWT_EXPIRES_IN || 60) * 60;
     // generate a json web token for this session
     const token = jwt.sign({
       user_sid: userProfile.user_sid,
       account_sid: userProfile.account_sid
-    }, process.env.JWT_SECRET, { expiresIn: parseInt(process.env.JWT_EXPIRES_IN || 60) * 60 });
+    }, process.env.JWT_SECRET, { expiresIn });
 
     logger.debug({
       user_sid: userProfile.user_sid,
@@ -76,6 +78,14 @@ router.post('/', async(req, res) => {
     }, 'generated jwt');
 
     res.json({jwt: token, ...userProfile});
+
+    /* Store jwt based on user_id after successful login */
+    await cacheClient.set({
+      redisKey: cacheClient.generateRedisKey('jwt', userProfile.user_sid, 'v2'),
+      value: token,
+      time: expiresIn,
+    });
+
   } catch (err) {
     sysError(logger, res, err);
   }

--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -1,11 +1,11 @@
 const router = require('express').Router();
 const User = require('../../models/user');
-const request = require('request');
 const {DbErrorBadRequest} = require('../../utils/errors');
 const {generateHashedPassword, verifyPassword} = require('../../utils/password-utils');
 const {promisePool} = require('../../db');
 const {validatePasswordSettings} = require('./utils');
 const {decrypt} = require('../../utils/encrypt-decrypt');
+const {cacheClient} = require('../../helpers');
 const sysError = require('../error');
 const retrieveMyDetails = `SELECT * 
 FROM users user
@@ -358,6 +358,8 @@ router.put('/:user_sid', async(req, res) => {
         'UPDATE users SET account_sid = ? WHERE user_sid = ?',
         [account_sid, user_sid]);
       if (0 === r.changedRows) throw new Error('database update failed');
+      const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+      await cacheClient.delete(redisKey);
     }
 
     if (service_provider_sid || service_provider_sid === null) {
@@ -365,6 +367,8 @@ router.put('/:user_sid', async(req, res) => {
         'UPDATE users SET service_provider_sid = ? WHERE user_sid = ?',
         [service_provider_sid, user_sid]);
       if (0 === r.changedRows) throw new Error('database update failed');
+      const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+      await cacheClient.delete(redisKey);
     }
 
     if (email) {
@@ -459,19 +463,10 @@ router.delete('/:user_sid', async(req, res) => {
     (req.user.hasAccountAuth && req.user.account_sid === user[0].account_sid) ||
     (req.user.hasServiceProviderAuth && req.user.service_provider_sid === user[0].service_provider_sid)) {
       await User.remove(user_sid);
-      //logout user after self-delete
-      if (req.user.user_sid === user_sid) {
-        request({
-          url:'http://localhost:3000/v1/logout',
-          method: 'POST',
-        }, (err) => {
-          if (err) {
-            logger.error(err, 'could not log out user');
-            return res.sendStatus(500);
-          }
-          logger.debug({user}, 'user deleted and logged out');
-        });
-      }
+      /* invalidate the jwt of the deleted user */
+      const redisKey = cacheClient.generateRedisKey('jwt', user_sid, 'v2');
+      await cacheClient.delete(redisKey);
+
       return res.sendStatus(204);
     } else {
       throw new DbErrorBadRequest('invalid request');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "upgrade-db": "node ./db/upgrade-jambonz-db.js",
     "coverage": "./node_modules/.bin/nyc --reporter html --report-dir ./coverage npm run test",
     "jslint": "eslint app.js lib",
+    "jslint:fix": "eslint app.js lib --fix",
     "prepare": "husky install"
   },
   "author": "Dave Horton",


### PR DESCRIPTION
This PR changes the handling of verifying and deleting the JWT in redis:
Before: 
* hashed jwt token got stored in redis as soon as a user logged out (blacklist)

After:
* hashed user_sid will be stored in redis after a successful login | sign in | register
* As soon as the password of a user was changed, the JWT gets delete from redis
* Every deleted user will result in a deletion of his redis jwt cache entry
* As soon as a user get promoted or demoted, his jwt gets deleted

All these cases require a new login
