### PR TITLE
Feature/delay middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,6 +64,7 @@ const {
 }, logger);
 const PORT = process.env.HTTP_PORT || 3000;
 const authStrategy = require('./lib/auth')(logger, retrieveKey);
+const {delayLoginMiddleware} = require('./lib/middleware');
 
 passport.use(authStrategy);
 
@@ -129,6 +130,7 @@ app.use(nocache());
 app.use(passport.initialize());
 app.use(cors());
 app.use(express.urlencoded({extended: true}));
+app.use(delayLoginMiddleware);
 app.use(unless(['/stripe'], express.json()));
 app.use('/v1', unless(
   [

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,27 @@
+const logger = require('./logger');
+
+function delayLoginMiddleware(req, res, next) {
+  if (req.path.includes('/login') || req.path.includes('/signin')) {
+    const randomDelay = Math.floor(Math.random() * 1000); // Generate a random delay between 0 and 1000 milliseconds
+    const sendStatus = res.sendStatus;
+    const json = res.json;
+    const randomDelayJson = randomDelay / 2;
+
+    logger.debug(`delayLoginMiddleware: sendStatus ${randomDelay} - json ${randomDelayJson}`);
+    res.sendStatus = function(status) {
+      setTimeout(() => {
+        sendStatus.call(res, status);
+      }, randomDelay);
+    };
+    res.json = function(body) {
+      setTimeout(() => {
+        json.call(res, body);
+      }, randomDelayJson);
+    };
+  }
+  next();
+}
+
+module.exports = {
+  delayLoginMiddleware
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,21 +2,26 @@ const logger = require('./logger');
 
 function delayLoginMiddleware(req, res, next) {
   if (req.path.includes('/login') || req.path.includes('/signin')) {
-    const randomDelay = Math.floor(Math.random() * 1000); // Generate a random delay between 0 and 1000 milliseconds
+    const min = 200;
+    const max = 1000;
+    /* Random delay between 200 - 1000ms */
+    const sendStatusDelay = Math.floor(Math.random() * (max - min + 1)) + min;
+
+    /* the res.json take longer, we decrease the max delay slightly to 0-800ms */
+    const jsonDelay = Math.floor(Math.random() * 800);
+    logger.debug(`delayLoginMiddleware: sendStatus ${sendStatusDelay} - json ${jsonDelay}`);
     const sendStatus = res.sendStatus;
     const json = res.json;
-    const randomDelayJson = randomDelay / 2;
 
-    logger.debug(`delayLoginMiddleware: sendStatus ${randomDelay} - json ${randomDelayJson}`);
     res.sendStatus = function(status) {
       setTimeout(() => {
         sendStatus.call(res, status);
-      }, randomDelay);
+      }, sendStatusDelay);
     };
     res.json = function(body) {
       setTimeout(() => {
         json.call(res, body);
-      }, randomDelayJson);
+      }, jsonDelay);
     };
   }
   next();


### PR DESCRIPTION
Background:
The response times of `login` and `sign in` allow conclusions to be drawn about the existence of user account during authentication.  e.g. a non-existing user has a faster response time compared to an existing user with correct/incorrect password. 

To avoid these conclusions just from the response time, this PR adds a `delay middleware` to the routes `/login` and `/sigin` that adds a random delay
* sendStatus - 200-1000ms delay
* json - 0-800ms delay 
