### PR TITLE
added retrieve jaeger trace endpoint.

### DIFF
--- a/lib/routes/api/recent-calls.js
+++ b/lib/routes/api/recent-calls.js
@@ -2,6 +2,8 @@ const router = require('express').Router();
 const sysError = require('../error');
 const {DbErrorBadRequest} = require('../../utils/errors');
 const {getHomerApiKey, getHomerSipTrace, getHomerPcap} = require('../../utils/homer-utils');
+const {getJaegerTrace} = require('../../utils/jaeger-utils');
+
 const parseAccountSid = (url) => {
   const arr = /Accounts\/([^\/]*)/.exec(url);
   if (arr) return arr[1];
@@ -90,6 +92,22 @@ router.get('/:call_id/pcap', async(req, res) => {
   } catch (err) {
     logger.error({err}, 'getHomerApiKey error retrieving sip traces from homer');
     res.sendStatus(err.statusCode || 500);
+  }
+});
+
+router.get('/trace/:trace_id', async(req, res) => {
+  const {logger} = req.app.locals;
+  const {trace_id} = req.params;
+  try {
+    const obj = await getJaegerTrace(logger, trace_id);
+    if (!obj) {
+      logger.info(`/RecentCalls: unable to get spans from jaeger for ${trace_id}`);
+      return res.sendStatus(404);
+    }
+    res.status(200).json(obj.result);
+  } catch (err) {
+    logger.error({err}, `/RecentCalls error retrieving jaeger trace ${trace_id}`);
+    res.sendStatus(500);
   }
 });
 

--- a/lib/utils/jaeger-utils.js
+++ b/lib/utils/jaeger-utils.js
@@ -1,0 +1,18 @@
+const bent = require('bent');
+const getJSON = bent(process.env.JAEGER_BASE_URL || 'http://127.0.0.1', 'GET', 'json', 200);
+
+const getJaegerTrace = async(logger, traceId) => {
+  if (!process.env.JAEGER_BASE_URL) {
+    logger.debug('getJaegerTrace: jaeger integration not installed');
+    return null;
+  }
+  try {
+    return await getJSON(`/api/v3/traces/${traceId}`);
+  } catch (err) {
+    logger.error({err}, `getJaegerTrace: Error retrieving spans for traceId ${traceId}`);
+  }
+};
+
+module.exports = {
+  getJaegerTrace
+};


### PR DESCRIPTION
Added Jaeger endpoint to recent-calls.js.

eslint should be good now.

returns the following payload:

```
{
	"resourceSpans": [
		{
			"resource": {
				"attributes": [
					{
						"key": "service.name",
						"value": {
							"stringValue": "jambonz-feature-server"
						}
					}
				]
			},
			"instrumentationLibrarySpans": [
				{
					"instrumentationLibrary": {
						"name": "jambonz-feature-server",
						"version": "undefined"
					},
					"spans": [
						{
							"traceId": "Hh12U4y9/tlmRYfpsJQItA==",
							"spanId": "i0XRoVdArS0=",
							"parentSpanId": "ybhSqf4rn8g=",
							"name": "lookupApplication",
							"kind": "SPAN_KIND_INTERNAL",
							"startTimeUnixNano": "1673825927082370000",
							"endTimeUnixNano": "1673825927087515000",
							"attributes": [
								{
									"key": "app.hook",
									"value": {
										"stringValue": "https://myhook.com/voice/start"
									}
								},
								{
									"key": "application_sid",
									"value": {
										"stringValue": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX"
									}
								},
								{
									"key": "service.name",
									"value": {
										"stringValue": "jambonz-feature-server"
									}
								},
								{
									"key": "telemetry.sdk.language",
									"value": {
										"stringValue": "nodejs"
									}
								},
								{
									"key": "telemetry.sdk.name",
									"value": {
										"stringValue": "opentelemetry"
									}
								},
								{
									"key": "telemetry.sdk.version",
									"value": {
										"stringValue": "1.8.0"
									}
								},
								{
									"key": "service.version",
									"value": {
										"stringValue": "v0.7.9"
									}
								},
								{
									"key": "internal.span.format",
									"value": {
										"stringValue": "jaeger"
									}
								}
							]
						}
					]
				}
			]
		}
	]
}
```