### PR TITLE
Fix 403 for SP calling RecentCalls/Alerts via /Accounts route

### DIFF
--- a/Dockerfile.db-create
+++ b/Dockerfile.db-create
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:18.15.1-alpine3.16 as base
+FROM --platform=linux/amd64 node:18.15-alpine3.16 as base
 
 RUN apk --update --no-cache add --virtual .builds-deps build-base python3
 

--- a/Dockerfile.db-create
+++ b/Dockerfile.db-create
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:18.14.1-alpine3.16 as base
+FROM --platform=linux/amd64 node:18.15.1-alpine3.16 as base
 
 RUN apk --update --no-cache add --virtual .builds-deps build-base python3
 

--- a/lib/routes/api/utils.js
+++ b/lib/routes/api/utils.js
@@ -242,7 +242,18 @@ const hasAccountPermissions = async(req, res, next) => {
 
     if (req.user.hasScope('service_provider')) {
       const service_provider_sid = parseServiceProviderSid(req);
-      if (service_provider_sid === req.user.service_provider_sid) return next();
+      const account_sid = parseAccountSid(req);
+      if (service_provider_sid) {
+        if (service_provider_sid === req.user.service_provider_sid) {
+          return next();
+        }
+      }
+      if (account_sid) {
+        const [r] = await Account.retrieve(account_sid);
+        if (r && r.service_provider_sid === req.user.service_provider_sid) {
+          return next();
+        }
+      }
     }
 
     if (req.user.hasScope('account')) {


### PR DESCRIPTION
/Accounts route is checked via function hasAccountPermissions that did not parse and check against Account sid from the route.
Added the check to allow SP to see this type of route

`/Accounts/877dd8a8-015a-4157-aq47-f7e293697580/RecentCalls`

update base mage to node:18.15-alpine3.16