### PR TITLE
Fix non existing attribute which made it impossible to record to wav

### DIFF
--- a/lib/record/s3.js
+++ b/lib/record/s3.js
@@ -59,7 +59,6 @@ async function upload(logger, socket) {
 
           /**encoder */
           let encoder;
-          logger.info({account}, 'db account retrieveal result');
           if (account && account.length && account[0].record_format === 'wav') {
             encoder = new wav.Writer({ channels: 2, sampleRate, bitDepth: 16 });
           } else {

--- a/lib/record/s3.js
+++ b/lib/record/s3.js
@@ -59,7 +59,8 @@ async function upload(logger, socket) {
 
           /**encoder */
           let encoder;
-          if (obj.output_format === 'wav') {
+          logger.info({account}, 'db account retrieveal result');
+          if (account && account.length && account[0].record_format === 'wav') {
             encoder = new wav.Writer({ channels: 2, sampleRate, bitDepth: 16 });
           } else {
             // default is mp3


### PR DESCRIPTION
The condition was checked over an attribute which does not exist. As the condition is checked outside of the if clause where body == account[0], `body.output_format` did not exist, and furthermore it should be named `record_format` as that is the name of the attribute.