### PR TITLE
Filter phone numbers result as account scope user

### DIFF
--- a/lib/routes/api/phone-numbers.js
+++ b/lib/routes/api/phone-numbers.js
@@ -120,6 +120,9 @@ router.get('/:sid', async(req, res) => {
         throw new DbErrorBadRequest('insufficient privileges');
       }
     }
+    if (req.user.hasAccountAuth && results.length > 1) {
+      return res.status(200).json(results.filter((r) => r.phone_number_sid === sid)[0]);
+    }
     return res.status(200).json(results[0]);
   }
   catch (err) {


### PR DESCRIPTION
GET PhoneNumbers/:sid call for account user was returning results for an account. I added a filter to filter according to the param sid provided to reduce to 1 result in the array.

How to test with postman:
1) have at least 2 numbers associated with the same account.
2) get an api key with account user scope
3) try to GET PhoneNumbers/:sid

Result: phone_number_sid in the request url is different form the one in the return value
Expected: phone_number_sid in the request url is the same to the one in the return value