### PR TITLE
Add try catch to getUpload to catch init errors with invalid credentials

### DIFF
--- a/lib/record/utils.js
+++ b/lib/record/utils.js
@@ -8,33 +8,37 @@ const getUploader = (Key, metadata, bucket_credential, logger) => {
     Key,
     metadata
   };
-  switch (bucket_credential.vendor) {
-    case 'aws_s3':
-      uploaderOpts.bucketCredential = {
-        credentials: {
-          accessKeyId: bucket_credential.access_key_id,
-          secretAccessKey: bucket_credential.secret_access_key,
-        },
-        region: bucket_credential.region || 'us-east-1'
-      };
-      return new S3MultipartUploadStream(logger, uploaderOpts);
-    case 'google':
-      const serviceKey = JSON.parse(bucket_credential.service_key);
-      uploaderOpts.bucketCredential = {
-        projectId: serviceKey.project_id,
-        credentials: {
-          client_email: serviceKey.client_email,
-          private_key: serviceKey.private_key
-        }
-      };
-      return new GoogleStorageUploadStream(logger, uploaderOpts);
-    case 'azure':
-      uploaderOpts.connection_string = bucket_credential.connection_string;
-      return new AzureStorageUploadStream(logger, uploaderOpts);
+  try {
+    switch (bucket_credential.vendor) {
+      case 'aws_s3':
+        uploaderOpts.bucketCredential = {
+          credentials: {
+            accessKeyId: bucket_credential.access_key_id,
+            secretAccessKey: bucket_credential.secret_access_key,
+          },
+          region: bucket_credential.region || 'us-east-1'
+        };
+        return new S3MultipartUploadStream(logger, uploaderOpts);
+      case 'google':
+        const serviceKey = JSON.parse(bucket_credential.service_key);
+        uploaderOpts.bucketCredential = {
+          projectId: serviceKey.project_id,
+          credentials: {
+            client_email: serviceKey.client_email,
+            private_key: serviceKey.private_key
+          }
+        };
+        return new GoogleStorageUploadStream(logger, uploaderOpts);
+      case 'azure':
+        uploaderOpts.connection_string = bucket_credential.connection_string;
+        return new AzureStorageUploadStream(logger, uploaderOpts);
 
-    default:
-      logger.error(`unknown bucket vendor: ${bucket_credential.vendor}`);
-      break;
+      default:
+        logger.error(`unknown bucket vendor: ${bucket_credential.vendor}`);
+        break;
+    }
+  } catch (err) {
+    logger.error(`Error creating uploader, vendor: ${bucket_credential.vendor}, reason: ${err.message}`);
   }
   return null;
 };


### PR DESCRIPTION


Reproduce:

1. Enable call recording on account level and add invalid storage credentials for e.g Azure
2. Call an application under that account
3. api-server will restart due to uncaught exceptions