### PR TITLE
Bug/unnecessary validation

### DIFF
--- a/lib/models/phone-number.js
+++ b/lib/models/phone-number.js
@@ -1,6 +1,7 @@
 const Model = require('./model');
 const {promisePool} = require('../db');
-const sql = 'SELECT * from phone_numbers WHERE account_sid = ? ORDER BY number';
+const sqlRetrieveAll = 'SELECT * from phone_numbers WHERE account_sid = ? ORDER BY number';
+const sqlRetrieveOne = 'SELECT * from phone_numbers WHERE phone_number_sid = ? AND account_sid = ? ORDER BY number';
 const sqlSP = `SELECT * 
 FROM phone_numbers 
 WHERE account_sid IN 
@@ -17,7 +18,7 @@ class PhoneNumber extends Model {
 
   static async retrieveAll(account_sid) {
     if (!account_sid) return await super.retrieveAll();
-    const [rows] = await promisePool.query(sql, account_sid);
+    const [rows] = await promisePool.query(sqlRetrieveAll, account_sid);
     return rows;
   }
   static async retrieveAllForSP(service_provider_sid) {
@@ -30,7 +31,7 @@ class PhoneNumber extends Model {
    */
   static async retrieve(sid, account_sid) {
     if (!account_sid) return super.retrieve(sid);
-    const [rows] = await promisePool.query(`${sql} AND phone_number_sid = ?`, [account_sid, sid]);
+    const [rows] = await promisePool.query(sqlRetrieveOne, [sid, account_sid]);
     return rows;
   }
 }

--- a/lib/routes/api/accounts.js
+++ b/lib/routes/api/accounts.js
@@ -250,8 +250,6 @@ async function validateCreateCall(logger, sid, req) {
   const {lookupAppBySid} = req.app.locals;
   const obj = req.body;
 
-  if (req.user.account_sid !== sid) throw new DbErrorBadRequest(`unauthorized createCall request for account ${sid}`);
-
   obj.account_sid = sid;
   if (!obj.from) throw new DbErrorBadRequest('missing from parameter');
   validateTo(obj.to);


### PR DESCRIPTION
This PR fixes an issue with the authentication when creating a new call via `

There is already a validation for permissions in `validateRequest`

Reproduce:
1. Login with a user scope `admin` or `service_provider`
2. Send a request to create a new call `{{base_url}}/v1/Accounts/:account_sid/Calls`

Expected:
- It is possible to create a call as admin
- It is possible to create a call as a service_provider containing the provided account_sid

Actuall:
- requests get rejected