### PR TITLE
Add Pagination to API Server

### DIFF
--- a/db/seed-integration-test.sql
+++ b/db/seed-integration-test.sql
@@ -17,8 +17,33 @@ insert into smpp_addresses (smpp_address_sid, ipv4, port, use_tls, is_primary)
 values('049078a0', '3.209.58.102', 3550, 1, 1);
 
 -- create one service provider and account
-insert into api_keys (api_key_sid, token) 
-values ('3f35518f-5a0d-4c2e-90a5-2407bb3b36f0', '38700987-c7a4-4685-a5bb-af378f9734de');
+insert into api_keys (api_key_sid, token, account_sid) 
+('3f35518f-5a0d-4c2e-90a5-2407bb3b36fa', '38700987-c7a4-4685-a5bb-af378f9734da', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('9a9f220e-1c64-4aa4-a94f-4221b8486f11', '32c687eb-f57e-476a-bbec-cd20ec1d840d', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('417110d1-ab8c-48f9-9f3a-be69eff2c6f8', '04868c2c-f187-4555-b847-19fe64507566', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('a89fd59b-f98b-4682-9d43-d78b6b5a2adb', 'd95188e7-fbda-4e92-86a9-dd7e90e6ba99', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('7e3f0f53-fff7-48f7-bd7f-07087e94b83b', '67484932-3207-4199-b172-5b25cab73912', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('cddaf2c0-e2a2-46ce-89b9-8e172b1a7f34', 'f8c44bf2-010d-4150-b198-98a10101eb1a', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('6a312d2e-cdbc-47f5-83ea-f2e704be43d8', '30067c66-c55b-4e1f-a4a3-7b5674bfa7fb', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('53a3aef1-ef93-4c5c-b89e-b45360ebd087', 'ce1cde34-0f83-4179-8e1f-11452376e12b', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('14aa8867-aa08-480b-b1d1-7dea30e63ffa', 'eef78786-0e4b-4ed5-aa6a-2d5ef836cb87', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('5be9494c-132a-48d2-b928-576ab0fbc144', 'a8ac120e-1178-40a4-990e-c173d8bf97ba', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('a8df3d6a-1f51-4efd-8a95-4925e9d00fa7', '841c2cff-5d6b-4776-9fc8-b87190bc0c9f', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('16c62198-5f1e-4aff-bda7-5a0121ce8cb0', '04be0f91-3772-47ae-a467-9c29da3a8a79', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('ca96f1cf-0158-4b20-bfcc-60b5a3b96461', '105dedda-fa3c-4146-b51e-5ca253bb6b88', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('1db27613-e5c3-49b3-970e-edfd15f97ab0', 'ee4b03b4-bdec-4b37-8d36-3cdd70e4a93b', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('d2482a65-2895-4131-9818-34331d9a512e', 'e6f1e1ef-9d66-4cab-b047-5dcdddcc5b4a', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('88851e5e-3241-4cdc-bede-8cf0740e8d4c', 'ee6f22bd-59e9-453a-8bb2-909ec1e7204c', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('787e7aec-163f-4b48-8bca-bd96c435a06e', 'f131067b-587e-456a-b432-ae389b6ded2c', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('d883ef06-582d-40cb-92da-63b1831dd170', 'c25699d5-7bc6-4892-b589-f744ae47b3dc', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('bed6d98b-2912-46d1-8830-fd1c0659b3b7', '1aef8599-6043-455c-b009-21b2266db7e4', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('6f4d5047-d1f0-4df0-b5c3-032dae1e784b', '08a3eac4-c399-43ce-855f-f268e58bee30', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('1d689103-f04b-4cc1-85d2-99e48e4d6b2c', 'd858643f-3cd7-4efb-992f-d293b791c623', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('9b67593f-29bc-4651-8412-2ad94c982115', '7c2e0eb8-7ebb-45bc-b5d0-2eb78eddd67a', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('7b377326-9c1b-44ae-b3af-0702689c9f8f', '5a887940-39c1-4ad4-92b4-1099e548a5bf', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('7f306b65-de74-4e17-8d1d-602908fc823a', '61f0bd74-71cd-4a12-85eb-9a2ce423749d', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('c3277d25-5c06-4ee1-bfda-102fb69785e4', 'ece4b921-440c-452d-9747-5ae7cc8268e5', '9351f46a-678c-43f5-b8a6-d4eb58d131af'),
+('62f3a6d7-b930-46e9-9687-eea65e80eb1e', '83378993-1dac-4880-9a42-a49da150c533', '9351f46a-678c-43f5-b8a6-d4eb58d131af');
 
 -- create one service provider and one account
 insert into service_providers (service_provider_sid, name, root_domain) 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,5 @@
+const isPaginationEnabled = process.env.PAGINATION === 'true';
+
+module.exports = {
+  isPaginationEnabled,
+};

--- a/lib/models/account.js
+++ b/lib/models/account.js
@@ -55,6 +55,13 @@ WHERE account_sid = ?
 AND effective_end_date IS NULL 
 AND pending = 0`;
 
+const retrieveAllSqlCount = `SELECT COUNT(*) AS total_items
+FROM accounts acc
+LEFT JOIN webhooks AS rh 
+ON acc.registration_hook_sid = rh.webhook_sid
+LEFT JOIN webhooks AS qh 
+ON acc.queue_event_hook_sid = qh.webhook_sid`;
+
 const extractBucketCredential = (obj) => {
   const {bucket_credential} = obj;
   if (bucket_credential) {
@@ -107,10 +114,48 @@ class Account extends Model {
       sql = `${sql} WHERE acc.service_provider_sid = ?`;
       args.push(service_provider_sid);
     }
+    return this.wrapPromise(sql, args);
+  }
+
+  static async retrieveAllPaginated(service_provider_sid, account_sid, limit, page) {
+    const offset = (page - 1) * limit;
+
+    const args = [];
+    let sql = retrieveSql;
+    let sqlCount = retrieveAllSqlCount;
+
+    if (account_sid) {
+      sql = `${sql} WHERE acc.account_sid = ?`;
+      sqlCount = `${sqlCount} WHERE acc.account_sid = ?`;
+      args.push(account_sid);
+
+    } else if (service_provider_sid) {
+      sql = `${sql} WHERE acc.service_provider_sid = ?`;
+      sqlCount = `${sqlCount} WHERE acc.service_provider_sid = ?`;
+      args.push(service_provider_sid);
+    }
+
+    const [row] = await promisePool.query(sqlCount, args);
+    const [{ total_items = 0 }] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    sql = `${sql} LIMIT ? OFFSET ?`;
+    args.push(limit, offset);
+    const data = await this.wrapPromise(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
+  }
+
+  static wrapPromise(sql, args) {
     return new Promise((resolve, reject) => {
       getMysqlConnection((err, conn) => {
         if (err) return reject(err);
-        conn.query({sql, nestTables: true}, args, (err, results, fields) => {
+        conn.query({ sql, nestTables: true }, args, (err, results, fields) => {
           conn.release();
           if (err) return reject(err);
           const r = transmogrifyResults(results);
@@ -130,17 +175,7 @@ class Account extends Model {
       sql = `${retrieveSql} WHERE acc.account_sid = ? AND acc.service_provider_sid = ?`;
       args.push(service_provider_sid);
     }
-    return new Promise((resolve, reject) => {
-      getMysqlConnection((err, conn) => {
-        if (err) return reject(err);
-        conn.query({sql, nestTables: true}, args, (err, results, fields) => {
-          conn.release();
-          if (err) return reject(err);
-          const r = transmogrifyResults(results);
-          resolve(r);
-        });
-      });
-    });
+    return this.wrapPromise(sql, args);
   }
 
   static async updateStripeCustomerId(sid, customerId) {
@@ -246,6 +281,16 @@ class Account extends Model {
       ]);
     }));
     return account_subscription_sid;
+  }
+
+  static async isPropertyAvailable(property, args) {
+    const sql = `SELECT *
+    FROM accounts acc
+    WHERE acc.service_provider_sid = ?
+    AND acc.${property} = ?`;
+
+    const result = await this.wrapPromise(sql, args);
+    return result.length === 0;
   }
 }
 

--- a/lib/models/api-key.js
+++ b/lib/models/api-key.js
@@ -1,6 +1,9 @@
 const Model = require('./model');
 const {getMysqlConnection} = require('../db');
 
+const sqlCountSP = 'SELECT COUNT(*) AS total_items from api_keys WHERE service_provider_sid = ?';
+const sqlCountAcc = 'SELECT COUNT(*) AS total_items from api_keys WHERE account_sid = ?';
+
 class ApiKey extends Model {
   constructor() {
     super();
@@ -15,6 +18,31 @@ class ApiKey extends Model {
       'SELECT * from api_keys WHERE account_sid IS NULL';
     const args = account_sid ? [account_sid] : [];
 
+    return this.wrapPromise(sql, args);
+  }
+
+  /**
+    * list all api keys for an account paginated
+    */
+  static async retrieveAllPaginated(account_sid, limit, page) {
+    const offset = (page - 1) * limit;
+
+    const [{ total_items = 0 }] = await this.wrapPromise(sqlCountAcc, [account_sid]);
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    const sql = 'SELECT * from api_keys WHERE account_sid = ? LIMIT ? OFFSET ?';
+    const args = [account_sid, limit, offset];
+    const data = await this.wrapPromise(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data
+    };
+  }
+
+  static wrapPromise(sql, args) {
     return new Promise((resolve, reject) => {
       getMysqlConnection((err, conn) => {
         if (err) return reject(err);
@@ -30,20 +58,31 @@ class ApiKey extends Model {
   /**
   * list all api keys for a service provider
   */
-  static retrieveAllForSP(service_provider_sid) {
+  static async retrieveAllForSP(service_provider_sid) {
     const sql = 'SELECT * from api_keys WHERE service_provider_sid = ?';
     const args = [service_provider_sid];
+    return this.wrapPromise(sql, args);
+  }
 
-    return new Promise((resolve, reject) => {
-      getMysqlConnection((err, conn) => {
-        if (err) return reject(err);
-        conn.query(sql, args, (err, results) => {
-          conn.release();
-          if (err) return reject(err);
-          resolve(results);
-        });
-      });
-    });
+  /**
+  * list all api keys for a service provider paginated
+  */
+  static async retrieveAllForSPPaginated(service_provider_sid, limit = 25, page = 1) {
+    const offset = (page - 1) * limit;
+
+    const [{total_items = 0}] = await this.wrapPromise(sqlCountSP, [service_provider_sid]);
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    const sql = 'SELECT * from api_keys WHERE service_provider_sid = ? LIMIT ? OFFSET ?';
+    const args = [service_provider_sid, limit, offset];
+    const data = await this.wrapPromise(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data
+    };
   }
 
   /**
@@ -53,16 +92,7 @@ class ApiKey extends Model {
     const sql = 'UPDATE api_keys SET last_used = NOW() WHERE account_sid = ?';
     const args = [account_sid];
 
-    return new Promise((resolve, reject) => {
-      getMysqlConnection((err, conn) => {
-        if (err) return reject(err);
-        conn.query(sql, args, (err, results) => {
-          conn.release();
-          if (err) return reject(err);
-          resolve(results);
-        });
-      });
-    });
+    return this.wrapPromise(sql, args);
   }
 }
 

--- a/lib/models/application.js
+++ b/lib/models/application.js
@@ -1,7 +1,17 @@
 const Model = require('./model');
 const {getMysqlConnection} = require('../db');
+const { promisePool } = require('../db');
 
 const retrieveSql = `SELECT * from applications app
+LEFT JOIN webhooks AS ch
+ON app.call_hook_sid = ch.webhook_sid
+LEFT JOIN webhooks AS sh
+ON app.call_status_hook_sid = sh.webhook_sid 
+LEFT JOIN webhooks AS mh
+ON app.messaging_hook_sid = mh.webhook_sid`;
+
+const retrieveAllSqlCount = `SELECT COUNT(*) as total_items
+FROM applications app
 LEFT JOIN webhooks AS ch
 ON app.call_hook_sid = ch.webhook_sid
 LEFT JOIN webhooks AS sh
@@ -50,6 +60,44 @@ class Application extends Model {
       sql = `${sql} WHERE account_sid in (SELECT account_sid from accounts WHERE service_provider_sid = ?)`;
       args.push(service_provider_sid);
     }
+    return this.wrapPromise(sql, args);
+  }
+
+  static async retrieveAllPaginated(service_provider_sid, account_sid, limit, page) {
+    const offset = (page - 1) * limit;
+
+    const args = [];
+    let sql = retrieveSql;
+    let sqlCount = retrieveAllSqlCount;
+
+    if (account_sid) {
+      sql = `${sql} WHERE app.account_sid = ?`;
+      sqlCount = `${sqlCount} WHERE app.account_sid = ?`;
+      args.push(account_sid);
+
+    } else if (service_provider_sid) {
+      sql = `${sql} WHERE account_sid in (SELECT account_sid from accounts WHERE service_provider_sid = ?)`;
+      sqlCount = `${sqlCount} WHERE account_sid in (SELECT account_sid from accounts WHERE service_provider_sid = ?)`;
+      args.push(service_provider_sid);
+    }
+
+    const [row] = await promisePool.query(sqlCount, args);
+    const [{total_items = 0}] = row;
+    const total_pages = Math.ceil(total_items  / limit) || 1;
+
+    sql = `${sql} LIMIT ? OFFSET ?`;
+    args.push(limit, offset);
+    const data = await this.wrapPromise(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
+  }
+
+  static wrapPromise(sql, args) {
     return new Promise((resolve, reject) => {
       getMysqlConnection((err, conn) => {
         if (err) return reject(err);
@@ -77,17 +125,7 @@ class Application extends Model {
       sql = `${sql} AND account_sid in (SELECT account_sid from accounts WHERE service_provider_sid = ?)`;
       args.push(service_provider_sid);
     }
-    return new Promise((resolve, reject) => {
-      getMysqlConnection((err, conn) => {
-        if (err) return reject(err);
-        conn.query({sql, nestTables: true}, args, (err, results, fields) => {
-          conn.release();
-          if (err) return reject(err);
-          const r = transmogrifyResults(results);
-          resolve(r);
-        });
-      });
-    });
+    return this.wrapPromise(sql, args);
   }
 
 }

--- a/lib/models/lcr-carrier-set-entry.js
+++ b/lib/models/lcr-carrier-set-entry.js
@@ -7,7 +7,7 @@ class LcrCarrierSetEntry extends Model {
   }
 
   static async retrieveAllByLcrRouteSid(sid) {
-    const sql = `SELECT * FROM ${this.table} WHERE lcr_route_sid = ? ORDER BY priority`;
+    const sql = `(SELECT * FROM ${this.table} WHERE lcr_route_sid = ?) ORDER BY priority`;
     const [rows] = await promisePool.query(sql, sid);
     return rows;
   }

--- a/lib/models/lcr-route.js
+++ b/lib/models/lcr-route.js
@@ -8,7 +8,7 @@ class LcrRoutes extends Model {
   }
 
   static async retrieveAllByLcrSid(sid) {
-    const sql = `SELECT * FROM ${this.table} WHERE lcr_sid = ? ORDER BY priority`;
+    const sql = `(SELECT * FROM ${this.table} WHERE lcr_sid = ?) ORDER BY priority`;
     const [rows] = await promisePool.query(sql, sid);
     return rows;
   }
@@ -23,6 +23,25 @@ class LcrRoutes extends Model {
     const sql = `SELECT COUNT(*) AS count FROM ${this.table} WHERE lcr_sid = ?`;
     const [rows] = await promisePool.query(sql, sid);
     return rows.length ? rows[0].count : 0;
+  }
+
+  static async retrieveAllByLcrSidPaginated(sid, limit, page) {
+    const offset = (page - 1) * limit;
+
+    const sql = `(SELECT * FROM ${this.table} WHERE lcr_sid = ? LIMIT ? OFFSET ? ) ORDER BY priority`;
+    const [rows] = await promisePool.query(sql, [sid, limit, offset]);
+
+    const countSql = `SELECT COUNT(*) AS total_items FROM ${this.table} WHERE lcr_sid = ?`;
+    const [row] = await promisePool.query(countSql, [sid]);
+    const [{ total_items = 0 }] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data: rows,
+    };
   }
 }
 

--- a/lib/models/lcr.js
+++ b/lib/models/lcr.js
@@ -6,16 +6,84 @@ class Lcr extends Model {
     super();
   }
 
+  static async countAll() {
+    const countSql = `SELECT COUNT(*) AS total_items FROM ${this.table}`;
+    const [row] = await promisePool.query(countSql);
+    const [{ total_items = 0 }] = row;
+    return total_items;
+  }
+
+  static async retrieveAllPaginated(limit, page) {
+    const offset = (page - 1) * limit;
+    const data = await super.retrieveAllPaginated([limit, offset]);
+
+    const total_items = await this.countAll();
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
+  }
+
   static async retrieveAllByAccountSid(account_sid) {
     const sql = `SELECT * FROM ${this.table} WHERE account_sid = ?`;
     const [rows] = await promisePool.query(sql, account_sid);
     return rows;
   }
 
+  static async countAcc(sid) {
+    const countSql = `SELECT COUNT(*) AS total_items FROM ${this.table} WHERE account_sid = ?`;
+    const [row] = await promisePool.query(countSql, [sid]);
+    const [{ total_items = 0 }] = row;
+    return total_items;
+  }
+
+  static async retrieveAllByAccountSidPaginated(sid, limit, page) {
+    const offset = (page - 1) * limit;
+    const sql = `SELECT * FROM ${this.table} WHERE account_sid = ? LIMIT ? OFFSET ?`;
+    const [rows] = await promisePool.query(sql, [sid, limit, offset]);
+
+    const total_items = await this.countAcc(sid);
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data: rows,
+    };
+  }
+
   static async retrieveAllByServiceProviderSid(sid) {
     const sql = `SELECT * FROM ${this.table} WHERE service_provider_sid = ?`;
     const [rows] = await promisePool.query(sql, sid);
     return rows;
+  }
+
+  static async countSP(sid) {
+    const countSql = `SELECT COUNT(*) AS total_items FROM ${this.table} WHERE service_provider_sid = ?`;
+    const [row] = await promisePool.query(countSql, [sid]);
+    const [{ total_items = 0 }] = row;
+    return total_items;
+  }
+
+  static async retrieveAllByServiceProviderSidPaginated(sid, limit, page) {
+    const offset = (page - 1) * limit;
+    const sql = `SELECT * FROM ${this.table} WHERE account_sid = ? LIMIT ? OFFSET ?`;
+    const [rows] = await promisePool.query(sql, [sid, limit, offset]);
+
+    const total_items = await this.countSP(sid);
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data: rows,
+    };
   }
 
   static async releaseDefaultEntry(sid) {

--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -80,6 +80,22 @@ class Model extends Emitter {
   }
 
   /**
+   * retrieve all objects paginated
+   */
+  static retrieveAllPaginated(args) {
+    return new Promise((resolve, reject) => {
+      getMysqlConnection((err, conn) => {
+        if (err) return reject(err);
+        conn.query(`SELECT * from ${this.table} LIMIT ? OFFSET ?`, args,  (err, results, fields) => {
+          conn.release();
+          if (err) return reject(err);
+          resolve(results);
+        });
+      });
+    });
+  }
+
+  /**
    * retrieve a specific object
    */
   static retrieve(sid) {

--- a/lib/models/phone-number.js
+++ b/lib/models/phone-number.js
@@ -10,6 +10,21 @@ WHERE account_sid IN
   FROM accounts 
   WHERE service_provider_sid = ?
 ) ORDER BY number`;
+const retrieveSqlCount = `SELECT COUNT(*) AS total_items 
+FROM phone_numbers pn`;
+
+const retrieveSqlCountForAcc = `SELECT COUNT(*) AS total_items 
+FROM phone_numbers pn 
+WHERE pn.account_sid = ?`;
+
+const retrieveSqlCountForSP = `SELECT COUNT(*) as total_items 
+FROM phone_numbers 
+WHERE account_sid IN 
+(
+  SELECT account_sid 
+  FROM accounts 
+  WHERE service_provider_sid = ?
+) ORDER BY number`;
 
 class PhoneNumber extends Model {
   constructor() {
@@ -21,9 +36,68 @@ class PhoneNumber extends Model {
     const [rows] = await promisePool.query(sqlRetrieveAll, account_sid);
     return rows;
   }
+
+  static async retrieveAllPaginated(account_sid, limit, page) {
+    const offset = (page - 1) * limit;
+    let data;
+    const countArgs = [];
+    let countSql;
+    if (!account_sid) {
+      data = await super.retrieveAllPaginated([limit, offset]);
+      countSql = retrieveSqlCount;
+    } else {
+      countSql = retrieveSqlCountForAcc;
+      countArgs.push(account_sid);
+      const sql = `${sqlRetrieveAll} LIMIT ? OFFSET ?`;
+      const [rows] = await promisePool.query(sql, [account_sid, limit, offset]);
+      data = rows;
+    }
+
+    const [row] = await promisePool.query(countSql, countArgs);
+    const [{ total_items = 0 }] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
+  }
+
   static async retrieveAllForSP(service_provider_sid) {
     const [rows] = await promisePool.query(sqlSP, service_provider_sid);
     return rows;
+  }
+
+
+  static async retrieveAllForSPPaginated(service_provider_sid, limit, page) {
+    const offset = (page - 1) * limit;
+    let data;
+    const countArgs = [];
+    let countSql;
+    if (!service_provider_sid) {
+      data = await super.retrieveAllPaginated([limit, offset]);
+      countSql = retrieveSqlCount;
+
+    } else {
+      countArgs.push(service_provider_sid);
+      countSql = retrieveSqlCountForSP;
+      const sql = `${sqlSP} LIMIT ? OFFSET ?`;
+      const [rows] = await promisePool.query(sql, [service_provider_sid, limit, offset]);
+      data = rows;
+    }
+
+    const [row] = await promisePool.query(countSql, countArgs);
+    const [{ total_items = 0 }] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
   }
 
   /**

--- a/lib/models/service-provider.js
+++ b/lib/models/service-provider.js
@@ -1,5 +1,5 @@
 const Model = require('./model');
-const {getMysqlConnection} = require('../db');
+const {getMysqlConnection, promisePool} = require('../db');
 
 const retrieveSql = `SELECT * from service_providers sp
 LEFT JOIN webhooks AS rh
@@ -29,25 +29,10 @@ class ServiceProvider extends Model {
    */
   static retrieveAll() {
     const sql = retrieveSql;
-    return new Promise((resolve, reject) => {
-      getMysqlConnection((err, conn) => {
-        if (err) return reject(err);
-        conn.query({sql, nestTables: true}, [], (err, results, fields) => {
-          conn.release();
-          if (err) return reject(err);
-          const r = transmogrifyResults(results);
-          resolve(r);
-        });
-      });
-    });
+    return this.wrapPromise(sql);
   }
 
-  /**
-   * retrieve a service provider
-   */
-  static retrieve(sid) {
-    const args = [sid];
-    const sql = `${retrieveSql} WHERE sp.service_provider_sid = ?`;
+  static async wrapPromise(sql, args = []) {
     return new Promise((resolve, reject) => {
       getMysqlConnection((err, conn) => {
         if (err) return reject(err);
@@ -59,6 +44,34 @@ class ServiceProvider extends Model {
         });
       });
     });
+  }
+
+  static async retrieveAllPaginated(limit, page) {
+    const offset = (page - 1) * limit;
+
+    const sql = `${retrieveSql} LIMIT ? OFFSET ?`;
+    const data = await this.wrapPromise(sql, [limit, offset]);
+
+    const countSql = 'SELECT COUNT(*) as total_items from service_providers sp';
+    const [row] = await promisePool.query(countSql, []);
+    const [{ total_items = 0 }] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
+  }
+
+  /**
+   * retrieve a service provider
+   */
+  static retrieve(sid) {
+    const args = [sid];
+    const sql = `${retrieveSql} WHERE sp.service_provider_sid = ?`;
+    return this.wrapPromise(sql, args);
   }
 }
 

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -29,6 +29,10 @@ LEFT JOIN service_providers as sp ON u.service_provider_sid = sp.service_provide
 LEFT JOIN accounts acc ON u.account_sid = acc.account_sid  
 WHERE u.service_provider_sid = ? 
 `;
+const sqlCountSP = 'SELECT COUNT(*) AS total_items from users WHERE service_provider_sid = ?';
+const sqlCountAcc = 'SELECT COUNT(*) AS total_items from users WHERE account_sid = ?';
+const sqlCount = 'SELECT COUNT(*) AS total_items from users';
+
 
 class User extends Model {
   constructor() {
@@ -40,14 +44,68 @@ class User extends Model {
     return rows;
   }
 
+  static async retrieveAllPaginated(limit, page) {
+    const offset = (page - 1) * limit;
+    const [row] = await promisePool.query(sqlCount);
+    const [{total_items = 0}] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    const sql = `${sqlAll} LIMIT ? OFFSET ?`;
+    const args = [limit, offset];
+    const [data] = await promisePool.query(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data
+    };
+  }
+
+
   static async retrieveAllForAccount(account_sid) {
     const [rows] = await promisePool.query(sqlAccount, [account_sid]);
     return rows;
   }
 
+  static async retrieveAllForAccountPaginated(account_sid, limit, page) {
+    const offset = (page - 1) * limit;
+    const [row] = await promisePool.query(sqlCountAcc, [account_sid]);
+    const [{total_items = 0}] = row;
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    const sql = `${sqlAccount} LIMIT ? OFFSET ?`;
+    const args = [account_sid, limit, offset];
+    const [data] = await promisePool.query(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data
+    };
+  }
+
   static async retrieveAllForServiceProvider(service_provider_sid) {
     const [rows] = await promisePool.query(sqlSP, [service_provider_sid]);
     return rows;
+  }
+
+  static async retrieveAllForServiceProviderPaginated(service_provider_sid, limit, page) {
+    const offset = (page - 1) * limit;
+    const [{total_items}] = await promisePool.query(sqlCountSP, [service_provider_sid]);
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    const sql = `${sqlSP} LIMIT ? OFFSET ?`;
+    const args = [service_provider_sid, limit, offset];
+    const [data] = await promisePool.query(sql, args);
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data
+    };
   }
 }
 

--- a/lib/models/voip-carrier.js
+++ b/lib/models/voip-carrier.js
@@ -1,8 +1,11 @@
 const Model = require('./model');
-const {promisePool} = require('../db');
-const retrieveSql = 'SELECT * from voip_carriers vc WHERE vc.account_sid = ?';
+const { promisePool } = require('../db');
+const retrieveSqlForAcc = 'SELECT * from voip_carriers vc WHERE vc.account_sid = ?';
 const retrieveSqlForSP = 'SELECT * from voip_carriers vc WHERE vc.service_provider_sid = ?';
 
+const retrieveSqlCount = 'SELECT COUNT(*) AS total_items from voip_carriers vc';
+const retrieveSqlCountForAcc = 'SELECT COUNT(*) AS total_items from voip_carriers vc WHERE vc.account_sid = ?';
+const retrieveSqlCountForSP = 'SELECT COUNT(*) AS total_items from voip_carriers vc WHERE vc.service_provider_sid = ?';
 
 class VoipCarrier extends Model {
   constructor() {
@@ -10,18 +13,89 @@ class VoipCarrier extends Model {
   }
   static async retrieveAll(account_sid) {
     if (!account_sid) return super.retrieveAll();
-    const [rows] = await promisePool.query(retrieveSql, account_sid);
+    const [rows] = await promisePool.query(retrieveSqlForAcc, account_sid);
     if (rows) {
       rows.map((r) => r.register_status = JSON.parse(r.register_status || '{}'));
     }
     return rows;
   }
+
+  static async countAll(filter) {
+    const {account_sid, service_provider_sid} = filter || {};
+    let countSql = retrieveSqlCount;
+    const countArgs = [];
+    if (account_sid) {
+      countArgs.push(account_sid);
+      countSql = retrieveSqlCountForAcc;
+    } else if (service_provider_sid) {
+      countArgs.push(service_provider_sid);
+      countSql = retrieveSqlCountForSP;
+    }
+
+    const [row] = await promisePool.query(countSql, countArgs);
+    const [{ total_items }] = row;
+    return total_items;
+  }
+
+  static async retrieveAllPaginated(account_sid, limit, page) {
+    const offset = (page - 1) * limit;
+
+    let data;
+    if (!account_sid) {
+      data = await super.retrieveAllPaginated([limit, offset]);
+    } else {
+      const [rows] = await promisePool.query(`${retrieveSqlForAcc} LIMIT ? OFFSET ?`, [account_sid, limit, offset]);
+      if (rows) {
+        rows.map((r) => r.register_status = JSON.parse(r.register_status || '{}'));
+        data = rows;
+      }
+    }
+
+    const total_items = await this.countAll({account_sid});
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
+  }
+
   static async retrieveAllForSP(service_provider_sid) {
     const [rows] = await promisePool.query(retrieveSqlForSP, service_provider_sid);
     if (rows) {
       rows.map((r) => r.register_status = JSON.parse(r.register_status || '{}'));
     }
     return rows;
+  }
+
+  static async retrieveAllForSPPaginated(service_provider_sid, limit, page) {
+    const offset = (page - 1) * limit;
+
+    let data;
+    if (!service_provider_sid) {
+      data = await super.retrieveAllPaginated([limit, offset]);
+
+    } else {
+      const sql = `${retrieveSqlForSP} LIMIT ? OFFSET ?`;
+      const [rows] = await promisePool.query(sql, [service_provider_sid, limit, offset]);
+
+      if (rows) {
+        rows.map((r) => r.register_status = JSON.parse(r.register_status || '{}'));
+        data = rows;
+      }
+    }
+
+    const total_items = await this.countAll({service_provider_sid});
+    const total_pages = Math.ceil(total_items / limit) || 1;
+
+    return {
+      total_items,
+      total_pages,
+      page,
+      data,
+    };
   }
 }
 

--- a/lib/routes/api/accounts.js
+++ b/lib/routes/api/accounts.js
@@ -25,6 +25,8 @@ const short = require('short-uuid');
 const VoipCarrier = require('../../models/voip-carrier');
 const { encrypt } = require('../../utils/encrypt-decrypt');
 const { testS3Storage, testGoogleStorage, testAzureStorage } = require('../../utils/storage-utils');
+const {validateQuery} = require('../../utils/validate-query');
+const { isPaginationEnabled } = require('../../config');
 const translator = short();
 
 let idx = 0;
@@ -92,23 +94,41 @@ router.get('/:sid/Applications', async(req, res) => {
   try {
     const account_sid = parseAccountSid(req);
     await validateRequest(req, account_sid);
-    const results = await Application.retrieveAll(null, account_sid);
+
+    let results;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await Application.retrieveAllPaginated(null, account_sid, req.query.limit, req.query.page);
+    } else {
+      results = await Application.retrieveAll(null, account_sid);
+    }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
   }
 });
+
 router.get('/:sid/VoipCarriers', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
     const account_sid = parseAccountSid(req);
     await validateRequest(req, account_sid);
-    const results = await VoipCarrier.retrieveAll(account_sid);
+
+    let results;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await VoipCarrier.retrieveAllPaginated(account_sid, req.query.limit, req.query.page);
+    } else {
+      results = await VoipCarrier.retrieveAll(account_sid);
+    }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
   }
 });
+
 router.put('/:sid/VoipCarriers/:voip_carrier_sid', async(req, res) => {
   const logger = req.app.locals.logger;
 
@@ -526,7 +546,14 @@ router.get('/', async(req, res) => {
   try {
     const service_provider_sid = req.user.hasServiceProviderAuth ? req.user.service_provider_sid : null;
     const account_sid = req.user.hasAccountAuth ? req.user.account_sid : null;
-    const results = await Account.retrieveAll(service_provider_sid, account_sid);
+    let results;
+    const {limit, page} = req.query || {};
+    if (isPaginationEnabled && limit && page) {
+      validateQuery(req.query);
+      results = await Account.retrieveAllPaginated(service_provider_sid, account_sid, req.query.limit, req.query.page);
+    } else {
+      results = await Account.retrieveAll(service_provider_sid, account_sid);
+    }
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
@@ -863,8 +890,13 @@ router.get('/:sid/ApiKeys', async(req, res) => {
   try {
     const sid = parseAccountSid(req);
     await validateRequest(req, sid);
-
-    const results = await ApiKey.retrieveAll(sid);
+    let results;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await ApiKey.retrieveAllPaginated(sid, req.query.limit, req.query.page);
+    } else {
+      results = await ApiKey.retrieveAll(sid);
+    }
     res.status(200).json(results);
     updateLastUsed(logger, sid, req).catch((err) => {});
   } catch (err) {
@@ -929,8 +961,20 @@ router.get('/:sid/Calls', async(req, res) => {
       to,
       callStatus
     });
+
+    let results = coerceNumbers(snakeCase(calls));
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = {
+        total_items: results.length,
+        total_pages: results.length / req.query.limit || 1,
+        page: req.query.page,
+        data: results,
+      };
+    }
+
     logger.debug(`retrieved ${calls.length} calls for account sid ${accountSid}`);
-    res.status(200).json(coerceNumbers(snakeCase(calls)));
+    res.status(200).json(results);
     updateLastUsed(logger, accountSid, req).catch((err) => {});
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/applications.js
+++ b/lib/routes/api/applications.js
@@ -8,6 +8,8 @@ const decorate = require('./decorate');
 const sysError = require('../error');
 const { validate } = require('@jambonz/verb-specifications');
 const { parseApplicationSid } = require('./utils');
+const { isPaginationEnabled } = require('../../config');
+const { validateQuery } = require('../../utils/validate-query');
 const preconditions = {
   'add': validateAdd,
   'update': validateUpdate
@@ -156,7 +158,20 @@ router.get('/', async(req, res) => {
   try {
     const service_provider_sid = req.user.hasServiceProviderAuth ? req.user.service_provider_sid : null;
     const account_sid = req.user.hasAccountAuth ? req.user.account_sid : null;
-    const results = await Application.retrieveAll(service_provider_sid, account_sid);
+    let results;
+
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await Application.retrieveAllPaginated(
+        service_provider_sid,
+        account_sid,
+        req.query.limit,
+        req.query.page
+      );
+    } else {
+      results = await Application.retrieveAll(service_provider_sid, account_sid);
+    }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/lcr-routes.js
+++ b/lib/routes/api/lcr-routes.js
@@ -5,6 +5,8 @@ const LcrCarrierSetEntry = require('../../models/lcr-carrier-set-entry');
 const decorate = require('./decorate');
 const {DbErrorBadRequest} = require('../../utils/errors');
 const sysError = require('../error');
+const { isPaginationEnabled } = require('../../config');
+const { validateQuery } = require('../../utils/validate-query');
 
 const validateAdd = async(req) => {
   // check if lcr sid is available
@@ -68,10 +70,18 @@ router.get('/', async(req, res) => {
   const lcr_sid = req.query.lcr_sid;
   try {
     await checkUserScope(req, lcr_sid);
-    const results = await LcrRoute.retrieveAllByLcrSid(lcr_sid);
-    for (const r of results) {
+    let results;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await LcrRoute.retrieveAllByLcrSidPaginated(lcr_sid, req.query.limit, req.query.page);
+    } else {
+      results = await LcrRoute.retrieveAllByLcrSid(lcr_sid);
+    }
+
+    for (const r of results?.data || results) {
       r.lcr_carrier_set_entries = await LcrCarrierSetEntry.retrieveAllByLcrRouteSid(r.lcr_route_sid);
     }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/lcrs.js
+++ b/lib/routes/api/lcrs.js
@@ -6,6 +6,8 @@ const decorate = require('./decorate');
 const {DbErrorBadRequest} = require('../../utils/errors');
 const sysError = require('../error');
 const ServiceProvider = require('../../models/service-provider');
+const { isPaginationEnabled } = require('../../config');
+const { validateQuery } = require('../../utils/validate-query');
 
 const validateAssociatedTarget = async(req, sid) => {
   const {lookupAccountBySid} = req.app.locals;
@@ -190,14 +192,59 @@ router.put('/:sid/Routes', async(req, res) => {
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
-    const results = req.user.hasAdminAuth ?
-      await Lcr.retrieveAll() : req.user.hasAccountAuth ?
-        await Lcr.retrieveAllByAccountSid(req.user.hasAccountAuth ? req.user.account_sid : null) :
-        await Lcr.retrieveAllByServiceProviderSid(req.user.service_provider_sid);
+    let results;
 
-    for (const lcr of results) {
-      lcr.number_routes = await LcrRoutes.countAllByLcrSid(lcr.lcr_sid);
+    if (req.user.hasAdminAuth) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await Lcr.retrieveAllPaginated(req.query.limit, req.query.page);
+      } else {
+        results = await Lcr.retrieveAll();
+      }
+
+    } else if (req.user.hasAccountAuth) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await Lcr.retrieveAllByAccountSidPaginated(
+          req.user.account_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        results = await Lcr.retrieveAllByAccountSid(req.user.account_sid);
+      }
+
+    } else if (req.user.hasServiceProviderAuth) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await Lcr.retrieveAllByServiceProviderSidPaginated(
+          req.user.service_provider_sid,
+          req.query.limit,
+          req.query.page
+        );
+
+        if (results.data.length) {
+          for (const lcr of results?.data || results) {
+            lcr.number_routes = await LcrRoutes.countAllByLcrSid(lcr.lcr_sid);
+          }
+        }
+
+      } else {
+        results = await Lcr.retrieveAllByServiceProviderSid(req.user.service_provider_sid);
+      }
     }
+
+    if (Array.isArray(results)) {
+      for (const lcr of results) {
+        lcr.number_routes = await LcrRoutes.countAllByLcrSid(lcr.lcr_sid);
+      }
+    } else {
+      for (const lcr of results.data) {
+        lcr.number_routes = await LcrRoutes.countAllByLcrSid(lcr.lcr_sid);
+      }
+    }
+
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/phone-numbers.js
+++ b/lib/routes/api/phone-numbers.js
@@ -13,7 +13,8 @@ const preconditions = {
 };
 const sysError = require('../error');
 const { parsePhoneNumberSid } = require('./utils');
-
+const { isPaginationEnabled } = require('../../config');
+const { validateQuery } = require('../../utils/validate-query');
 
 /* check for required fields when adding */
 async function validateAdd(req) {
@@ -94,9 +95,31 @@ decorate(router, PhoneNumber, ['add', 'update', 'delete'], preconditions);
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
-    const results = req.user.hasServiceProviderAuth ?
-      await PhoneNumber.retrieveAllForSP(req.user.service_provider_sid) :
-      await PhoneNumber.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null);
+    let results;
+    if (req.user.hasServiceProviderAuth) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await PhoneNumber.retrieveAllForSPPaginated(
+          req.user.service_provider_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        results = await PhoneNumber.retrieveAllForSP(req.user.service_provider_sid);
+      }
+    } else {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await PhoneNumber.retrieveAllPaginated(
+          req.user.account_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        results = await PhoneNumber.retrieveAll(req.user.account_sid);
+      }
+    }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);

--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -15,6 +15,8 @@ const {
 } = require('./utils');
 const sysError = require('../error');
 const decorate = require('./decorate');
+const { validateQuery } = require('../../utils/validate-query');
+const { isPaginationEnabled } = require('../../config');
 const preconditions = {
   'delete': noActiveAccountsOrUsers
 };
@@ -103,13 +105,24 @@ router.use('/:sid/Limits', hasServiceProviderPermissions, require('./limits'));
 router.use('/:sid/PredefinedCarriers', hasServiceProviderPermissions, require('./add-from-predefined-carrier'));
 router.get('/:sid/Accounts', async(req, res) => {
   const logger = req.app.locals.logger;
+  const {limit, page} = req.query;
   try {
     await validateRetrieve(req);
     const service_provider_sid = parseServiceProviderSid(req);
-    let results = await Account.retrieveAll(service_provider_sid);
-    if (req.user.hasScope('account')) {
-      results = results.filter((r) => r.account_sid === req.user.account_sid);
+    const account_sid = req.user.hasScope('account') ? req.user.account_sid : null;
+    let results;
+    if (isPaginationEnabled && limit && page) {
+      validateQuery(req.query);
+      results = await Account.retrieveAllPaginated(
+        service_provider_sid,
+        account_sid,
+        req.query.limit,
+        req.query.page
+      );
+    } else {
+      results = await Account.retrieveAll(service_provider_sid);
     }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
@@ -121,41 +134,98 @@ router.get('/:sid/Applications', async(req, res) => {
   try {
     await validateRetrieve(req);
     const service_provider_sid = parseServiceProviderSid(req);
-    let results = await Application.retrieveAll(service_provider_sid);
-    if (req.user.hasScope('account')) {
-      results = results.filter((r) => r.account_sid === req.user.account_sid);
+    const account_sid = req.user.hasScope('account') ? req.user.account_sid : null;
+
+    let results;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await Application.retrieveAllPaginated(
+        service_provider_sid,
+        account_sid,
+        req.query.limit,
+        req.query.page
+      );
+
+    } else {
+      results = await Application.retrieveAll(service_provider_sid, account_sid);
     }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
   }
 });
+
+router.get('/:sid/Accounts/Availability', async(req, res) => {
+  const logger = req.app.locals.logger;
+  const { sid } = req.params;
+  const { property, value } = req.query;
+  try {
+    const results = await Account.isPropertyAvailable(property, [sid, value]);
+
+    res.status(200).json(results);
+  } catch (err) {
+    sysError(logger, res, err);
+  }
+});
+
 router.get('/:sid/PhoneNumbers', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
     await validateRetrieve(req);
+    let results;
     const service_provider_sid = parseServiceProviderSid(req);
-    let results = await PhoneNumber.retrieveAllForSP(service_provider_sid);
-    if (req.user.hasScope('account')) {
-      results = results.filter((r) => r.account_sid === req.user.account_sid);
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      results = await PhoneNumber.retrieveAllForSPPaginated(service_provider_sid, req.query.limit, req.query.page);
+      if (req.user.hasScope('account')) {
+        results.data = results.data.filter((r) => r.account_sid === req.user.account_sid);
+      }
+    } else {
+      results = await PhoneNumber.retrieveAllForSP(service_provider_sid);
+      if (req.user.hasScope('account')) {
+        results = results.filter((r) => r.account_sid === req.user.account_sid);
+      }
     }
+
     res.status(200).json(results);
   } catch (err) {
     sysError(logger, res, err);
   }
 });
+
 router.get('/:sid/VoipCarriers', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
     await validateRetrieve(req);
     const service_provider_sid = parseServiceProviderSid(req);
-    const carriers = await VoipCarrier.retrieveAllForSP(service_provider_sid);
+    const account_sid = req.user.hasScope('account') ? req.user.account_sid : null;
+    let carriers;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      if (account_sid) {
+        carriers = await VoipCarrier.retrieveAllPaginated(
+          account_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        carriers = await VoipCarrier.retrieveAllForSPPaginated(
+          service_provider_sid,
+          req.query.limit,
+          req.query.page
+        );
+      }
 
-    if (req.user.hasScope('account')) {
-      return res.status(200).json(carriers.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid));
+    } else {
+      if (account_sid) {
+        carriers = await VoipCarrier.retrieveAll(account_sid);
+      } else {
+        carriers = await VoipCarrier.retrieveAllForSP(service_provider_sid);
+      }
     }
 
-    res.status(200).json(carriers);
+    return res.status(200).json(carriers);
   } catch (err) {
     sysError(logger, res, err);
   }
@@ -185,15 +255,31 @@ router.put('/:sid/VoipCarriers/:voip_carrier_sid', async(req, res) => {
     sysError(logger, res, err);
   }
 });
+
 router.get('/:sid/ApiKeys', async(req, res) => {
   const logger = req.app.locals.logger;
-  const {sid} = req.params;
+  const { sid } = req.params;
   try {
     await validateRetrieve(req);
-    let results = await ApiKey.retrieveAllForSP(sid);
-    if (req.user.hasScope('account')) {
-      results = results.filter((r) => r.account_sid === req.user.account_sid);
+
+    const account_sid = req.user.hasScope('account') ? req.user.account_sid : null;
+    let results;
+    if (isPaginationEnabled) {
+      validateQuery(req.query);
+      if (account_sid) {
+        results = await ApiKey.retrieveAllPaginated(account_sid, req.query.limit, req.query.page);
+      } else {
+        results = await ApiKey.retrieveAllForSPPaginated(sid, req.query.limit, req.query.page);
+      }
+
+    } else {
+      if (account_sid) {
+        results = await ApiKey.retrieveAll(account_sid);
+      } else {
+        results = await ApiKey.retrieveAllForSP(sid);
+      }
     }
+
     res.status(200).json(results);
     await ApiKey.updateLastUsed(sid);
   } catch (err) {
@@ -226,13 +312,26 @@ router.post('/', async(req, res) => {
 /* list */
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
+  const { limit, page } = req.query;
   try {
-    const results = await ServiceProvider.retrieveAll();
-    logger.debug({results, user: req.user}, 'ServiceProvider.retrieveAll');
-    if (req.user.hasScope('service_provider') || req.user.hasScope('account')) {
-      logger.debug(`Filtering results for ${req.user.service_provider_sid}`);
-      return res.status(200).json(results.filter((e) => req.user.service_provider_sid === e.service_provider_sid));
+    let results;
+    if (isPaginationEnabled && limit && page) {
+      validateQuery(req.query);
+      results = await ServiceProvider.retrieveAllPaginated(req.query.limit, req.query.page);
+      if (req.user.hasScope('service_provider') || req.user.hasScope('account')) {
+        logger.debug(`Filtering results for ${req.user.service_provider_sid}`);
+        results.data = results.data.filter((e) => req.user.service_provider_sid === e.service_provider_sid);
+      }
+
+    } else {
+      results = await ServiceProvider.retrieveAll();
+      if (req.user.hasScope('service_provider') || req.user.hasScope('account')) {
+        logger.debug(`Filtering results for ${req.user.service_provider_sid}`);
+        results = results.filter((e) => req.user.service_provider_sid === e.service_provider_sid);
+      }
     }
+
+    logger.debug({ results, user: req.user }, 'ServiceProvider.retrieveAll');
 
     res.status(200).json(results);
   } catch (err) {

--- a/lib/routes/api/users.js
+++ b/lib/routes/api/users.js
@@ -3,10 +3,13 @@ const User = require('../../models/user');
 const {DbErrorBadRequest, BadRequestError, DbErrorForbidden} = require('../../utils/errors');
 const {generateHashedPassword, verifyPassword} = require('../../utils/password-utils');
 const {promisePool} = require('../../db');
-const {validatePasswordSettings, parseUserSid} = require('./utils');
+const {validatePasswordSettings, parseUserSid, hasUserScope} = require('./utils');
 const {decrypt} = require('../../utils/encrypt-decrypt');
 const {cacheClient} = require('../../helpers');
 const sysError = require('../error');
+const { isPaginationEnabled } = require('../../config');
+const { validateQuery } = require('../../utils/validate-query');
+
 const retrieveMyDetails = `SELECT * 
 FROM users user
 JOIN accounts AS account ON account.account_sid = user.account_sid 
@@ -141,63 +144,88 @@ const ensureUserRetrievalIsAllowed = (req, user) => {
   }
 };
 
+const buildUser = (user) => {
+  const {
+    user_sid,
+    name,
+    email,
+    force_change,
+    is_active,
+    account_sid,
+    service_provider_sid,
+    account_name,
+    service_provider_name,
+    cognigy_user_id,
+  } = user || {};
+  let scope;
+  if (account_sid && service_provider_sid) {
+    scope = 'account';
+  } else if (service_provider_sid) {
+    scope = 'service_provider';
+  } else {
+    scope = 'admin';
+  }
+
+  const obj = {
+    user_sid,
+    name,
+    email,
+    scope,
+    force_change,
+    is_active,
+    ...(account_sid && { account_sid }),
+    ...(account_name && { account_name }),
+    ...(service_provider_sid && { service_provider_sid }),
+    ...(service_provider_name && { service_provider_name }),
+    ...(cognigy_user_id && { cognigy_user_id }),
+  };
+  return obj;
+};
+
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
 
-  let usersList;
+  let results;
   try {
-    let results;
-    if (req.user.hasAdminAuth) {
-      results = await User.retrieveAll();
-    }
-    else if (req.user.hasAccountAuth) {
-      results = await User.retrieveAllForAccount(req.user.account_sid, true);
-    }
-    else if (req.user.hasServiceProviderAuth) {
-      results = await User.retrieveAllForServiceProvider(req.user.service_provider_sid, true);
+    if (hasUserScope('admin', req)) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await User.retrieveAllPaginated(req.query.limit, req.query.page);
+      } else {
+        results = await User.retrieveAll();
+      }
+    } else if (hasUserScope('account', req)) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await User.retrieveAllForAccountPaginated(req.user.account_sid, req.query.limit, req.query.page);
+      } else {
+        results = await User.retrieveAllForAccount(req.user.account_sid, true);
+      }
+    } else if (hasUserScope('sp', req)) {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await User.retrieveAllForServiceProviderPaginated(
+          req.user.service_provider_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        results = await User.retrieveAllForServiceProvider(req.user.service_provider_sid, true);
+      }
     }
 
     if (results.length === 0) throw new Error('failure retrieving users list');
 
-    usersList = results.map((user) => {
-      const {
-        user_sid,
-        name,
-        email,
-        force_change,
-        is_active,
-        account_sid,
-        service_provider_sid,
-        account_name,
-        service_provider_name
-      } = user;
-      let scope;
-      if (account_sid && service_provider_sid) {
-        scope = 'account';
-      } else if (service_provider_sid) {
-        scope = 'service_provider';
-      } else {
-        scope = 'admin';
-      }
+    if (isPaginationEnabled) {
+      results.data = results.data.map((user) => buildUser(user));
+    } else {
+      results = results.map((user) => buildUser(user));
+    }
 
-      const obj = {
-        user_sid,
-        name,
-        email,
-        scope,
-        force_change,
-        is_active,
-        ...(account_sid && {account_sid}),
-        ...(account_name && {account_name}),
-        ...(service_provider_sid && {service_provider_sid}),
-        ...(service_provider_name && {service_provider_name})
-      };
-      return obj;
-    });
   } catch (err) {
     sysError(logger, res, err);
   }
-  res.status(200).json(usersList);
+  res.status(200).json(results);
 });
 
 router.get('/me', async(req, res) => {

--- a/lib/routes/api/utils.js
+++ b/lib/routes/api/utils.js
@@ -313,6 +313,22 @@ const hasServiceProviderPermissions = (req, res, next) => {
   }
 };
 
+const hasUserScope = (scope, req) => {
+  const {user} = req || {};
+  const {hasServiceProviderAuth, hasAccountAuth, hasAdminAuth} = user || {};
+
+  switch (scope) {
+    case 'admin':
+      return hasAdminAuth;
+    case 'sp':
+      return hasServiceProviderAuth;
+    case 'account':
+      return hasAccountAuth;
+    default:
+      return false;
+  }
+};
+
 const checkLimits = async(req, res, next) => {
   const logger = req.app.locals.logger;
   if (process.env.APPLY_JAMBONZ_DB_LIMITS && req.user.hasScope('account')) {
@@ -460,5 +476,6 @@ module.exports = {
   checkLimits,
   enableSubspace,
   disableSubspace,
-  validatePasswordSettings
+  validatePasswordSettings,
+  hasUserScope,
 };

--- a/lib/routes/api/voip-carriers.js
+++ b/lib/routes/api/voip-carriers.js
@@ -5,6 +5,8 @@ const {promisePool} = require('../../db');
 const decorate = require('./decorate');
 const sysError = require('../error');
 const { parseVoipCarrierSid } = require('./utils');
+const { isPaginationEnabled } = require('../../config');
+const { validateQuery } = require('../../utils/validate-query');
 
 const validate = async(req) => {
   const {lookupAppBySid, lookupAccountBySid} = req.app.locals;
@@ -74,9 +76,33 @@ decorate(router, VoipCarrier, ['add', 'update', 'delete'], preconditions);
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
   try {
-    const results = req.user.hasAdminAuth ?
-      await VoipCarrier.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null) :
-      await VoipCarrier.retrieveAllForSP(req.user.service_provider_sid);
+    let results;
+
+    if (req.user.hasAdminAuth) {
+      const account_sid = req.user.hasAccountAuth ? req.user.account_sid : null;
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await VoipCarrier.retrieveAllPaginated(
+          account_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        results = await VoipCarrier.retrieveAll(account_sid);
+      }
+
+    } else {
+      if (isPaginationEnabled) {
+        validateQuery(req.query);
+        results = await VoipCarrier.retrieveAllForSPPaginated(
+          req.user.service_provider_sid,
+          req.query.limit,
+          req.query.page
+        );
+      } else {
+        results = await VoipCarrier.retrieveAllForSP(req.user.service_provider_sid);
+      }
+    }
 
     if (req.user.hasScope('account')) {
       return res.status(200).json(results.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid));

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -2,7 +2,13 @@ const express = require('express');
 const swaggerUi = require('swagger-ui-express');
 const YAML = require('yamljs');
 const path = require('path');
-const swaggerDocument = YAML.load(path.resolve(__dirname, '../swagger/swagger.yaml'));
+const { isPaginationEnabled } = require('../config');
+
+let swaggerFilepath = '../swagger/swagger.yaml';
+if (isPaginationEnabled) {
+  swaggerFilepath = '../swagger/swagger-pagination.yaml';
+}
+const swaggerDocument = YAML.load(path.resolve(__dirname, swaggerFilepath));
 const api = require('./api');
 const stripe = require('./stripe');
 const {checkLimits} = require('./api/utils');

--- a/lib/swagger/swagger-pagination.yaml
+++ b/lib/swagger/swagger-pagination.yaml
@@ -1,0 +1,5557 @@
+openapi: 3.0.0
+info:
+  title: jambonz REST API
+  description: jambonz REST API
+  contact:
+    email: daveh@drachtio.org
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  version: 1.0.0
+servers:
+  - url: /v1
+    description: jambonz API server
+tags:
+  - name: Authentication
+    description: Authentication operations
+  - name: Accounts
+    description: Accounts operations
+  - name: Users
+    description: Users operations
+  - name: Applications
+    description: Applications operations
+  - name: Phone Numbers
+    description: Phone Numbers operations
+  - name: Api Keys
+    description: Api Keys operations
+  - name: Service Providers
+    description: Service Providers operations
+  - name: SBCs
+    description: SBCs operations
+  - name: Voip Carriers
+    description: Voip Carriers operations   
+  - name: Sip Gateways
+    description: Sip Gateways operations
+  - name: Smpp Gateways
+    description: Smpp Gateways operations   
+  - name: Webhooks
+    description: Webhooks operations
+  - name: Microsoft Teams Tenants
+    description: Microsoft Teams Tenants operations
+  - name: Lcrs
+    description: Least Cost Routing operations
+  - name: LcrRoutes
+    description: Least Cost Routing Routes operations
+  - name: LcrCarrierSetEntries
+    description: Least Cost Routing Carrier Set Entries operation
+paths:
+  /PredefinedCarriers:
+    get:
+      summary: get a list of predefined carriers
+      operationId: listPredefinedCarriers
+      responses:
+        200:
+          description: list of predefined carriers
+          content:
+            application/json:
+              schema:
+                type:
+                  array
+                items:
+                  $ref: '#/components/schemas/PredefinedCarrier'
+  /Accounts/{AccountSid}/PredefinedCarriers/{PredefinedCarrierSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: PredefinedCarrierSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+       - Accounts
+      summary: add a VoiPCarrier to an account based on PredefinedCarrier template
+      operationId: createAccountVoipCarrierFromTemplate
+      responses:
+        201:
+          description:  voip carrier successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'      
+  /Sbcs:
+    post:
+      tags:
+        - SBCs
+      summary: add an SBC address
+      operationId: createSbc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ipv4:
+                  type: string
+                port:
+                  type: number
+                service_provider_sid:
+                  type: string
+                  description: service provider scope for the generated api key
+              required:
+                - ipv4
+      responses:
+        201:
+          description:  sbc address successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - SBCs
+      summary: retrieve public IP addresses of the jambonz SBCs
+      operationId: listSbcs
+      parameters:
+        - in: query
+          name: service_provider_sid
+          required: false
+          schema:
+            type: string
+            description: return only the SBCs operated for the sole use of this service provider
+      responses:
+        200:
+          description: list of SBC addresses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    ipv4:
+                      type: string
+                      description: ip address of one of our Sbcs 
+                  required:
+                    - ipv4
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Sbcs/{SbcSid}:
+      parameters:
+      - name: SbcSid
+        in: path
+        required: true
+        schema:
+          type: string
+      delete:
+        tags:
+          - SBCs
+        summary: delete SBC address
+        operationId: deleteSbcAddress      
+        responses:
+          200:
+            description: sbc address deleted
+          404:
+            description: sbc address not found
+  /Smpps:
+    get:
+      summary: retrieve public IP addresses of the jambonz smpp servers
+      operationId: listSmpps
+      parameters:
+        - in: query
+          name: service_provider_sid
+          required: false
+          schema:
+            type: string
+            description: return only the smpp servers operated for the sole use of this service provider
+      responses:
+        200:
+          description: list of smpp server addresses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    ipv4:
+                      type: string
+                      description: ip address of one of our Sbcs
+                    port:
+                      type: number
+                    use_tls:
+                      type: boolean
+                    is_primary:
+                      type: boolean
+                  required:
+                    - ipv4
+                    - port
+                    - use_tls
+                    - is_primary
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /ApiKeys:
+    post:
+      tags:
+        - Api Keys
+      summary: create an api key
+      operationId: createApikey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                service_provider_sid:
+                  type: string
+                  description: service provider scope for the generated api key
+                account_sid:
+                  type: string
+                  description: account scope for the generated api key
+                expiry_secs:
+                  type: number
+                  description: duration of key validity, in seconds
+      responses:
+        201:
+          description: api key successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulApiKeyAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+        500:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /ApiKeys/{ApiKeySid}:
+      parameters:
+      - name: ApiKeySid
+        in: path
+        required: true
+        schema:
+          type: string
+      delete:
+        tags:
+          - Api Keys
+        summary: delete api key
+        operationId: deleteApiKey          
+        responses:
+          200:
+            description: api key deleted
+          404:
+            description: api key or account not found
+  /logout:
+    post:
+      tags:
+        - Authentication
+      summary: log out and deactivate jwt
+      operationId: logoutUser
+      responses:
+        204:
+          description: user logged out
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /forgot-password:
+    post:
+      tags:
+        - Authentication
+      summary: send link to reset password
+      operationId: forgotPassword
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+      responses:
+        204:
+          description: email sent
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+              example:
+                msg: service_provider_sid is missing
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /change-password:
+    post:
+      tags:
+        - Authentication
+      summary: changePassword
+      operationId: changePassword
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                old_password:
+                  type: string
+                new_password:
+                  type: string
+      responses:
+        204:
+          description: password changed
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+              example:
+                msg: service_provider_sid is missing
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Users:
+    get:
+      tags:
+        - Users
+      summary: list all users
+      operationId: listUsers
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponsePaginatedUserProfile'
+        '403':
+          description: Unauthorized
+        '500':
+          description: System error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    post:
+      tags:
+        - Users
+      summary: Create a new user
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreate'
+      responses:
+        '201':
+          description: User created
+        '403':
+          description: User creation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '500':
+          description: System error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Users/{userSid}:
+    parameters:
+      - name: userSid
+        in: path
+        required: true
+        description: ID of the user to retrieve
+        schema:
+          type: string
+    get:
+      tags:
+        - Users
+      summary: Retrieve user information
+      operationId: getUser
+      responses:
+        '200':
+          description: User information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '403':
+          description: User information retrieval failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '500':
+          description: System error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - Users
+      summary: Update user information
+      operationId: updateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdate'
+      responses:
+        '204':
+          description: User updated
+        '403':
+          description: User update failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        '500':
+          description: System error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    delete:
+      tags:
+        - Users
+      summary: Delete a user
+      operationId: deleteUser
+      responses:
+        '204':
+          description: User deleted
+        '404':
+          description: User not found
+        '403':
+          description: Unauthorized
+        '500':
+          description: System error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Users/me:
+    get:
+      tags:
+        - Users
+      summary: Retrieve details about logged-in user and associated account
+      operationId: getMyDetails
+      responses:
+        '200':
+          description: Full-ish detail about the logged-in user and account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAndAccountDetail'
+        '500':
+          description: System error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Availability:
+    get:
+      summary: check if a limited-availability entity such as a subdomain, email or phone number is already in use
+      operationId: checkAvailability
+      parameters:
+        - in: query
+          name: type
+          required: true
+          schema:
+            type: string
+            enum:
+              - email
+              - phone
+              - subdomain
+            example: subdomain
+        - in: query
+          name: value
+          required: true
+          schema:
+            type: string
+            example: mycorp.sip.jambonz.cloud
+      responses:
+        200:
+          description: indicates whether value is already in use
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                    description: true if value requested is available
+                required:
+                  - available
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /AccountTest/{ServiceProviderSid}:
+    parameters:
+    - name: ServiceProviderSid
+      in: path
+      required: true
+      style: simple
+      explode: false
+      schema:
+        type: string
+    get:
+      summary: get test phone numbers and applications
+      operationId: getTestData
+      responses:
+        200:
+          description: test data for this service provider
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  phonenumbers:
+                    type: array
+                    items:
+                      type: string
+                  applications:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Application'
+        404:
+          description: Service Provider Not Found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /Webhooks/{WebhookSid}:
+    parameters:
+      - name: WebhookSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    get:
+      tags:
+        - Webhooks
+      summary: retrieve webhook
+      operationId: getWebhook
+      responses:
+        200:
+          description: webhook found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Webhook'
+        404:
+          description: webhook not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /VoipCarriers:
+    post:
+      tags:
+        - Voip Carriers
+      summary: create voip carrier
+      operationId: createVoipCarrier
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: voip carrier name
+                  example: fastco
+                description:
+                  type: string
+                  example: my US sip trunking provider
+                account_sid:
+                  type: string
+                application_sid:
+                  type: string
+                e164_leading_plus:
+                  type: boolean
+                  description: whether a leading + is required on INVITEs to this provider
+                  example: true
+                requires_register:
+                  type: boolean
+                  description: wehther this provider requires us to send a REGISTER to them in order to receive calls
+                register_username:
+                  type: string
+                  description: sip username to authenticate with, if registration is required
+                  example: foo
+                register_sip_realm:
+                  type: string
+                  description: sip realm to authenticate with, if registration is required
+                  example: sip.fastco.com
+                register_password:
+                  type: string
+                  description: sip password to authenticate with, if registration is required
+                  example: bar
+                register_from_user:
+                  type: string
+                  description: optional username to apply in From header
+                register_from_domain:
+                  type: string
+                  description: optional domain to apply in From header
+                register_public_ip_in_contact:
+                  type: boolean
+                  description: if true, use our public ip in Contact header; otherwise, use sip realm
+                tech_prefix:
+                  type: string
+                  description: prefix to be applied to the called number for outbound call attempts
+                inbound_auth_username:
+                  type: string
+                  description: challenge inbound calls with this username/password if supplied
+                inbound_auth_password:
+                  type: string
+                  description: challenge inbound calls with this username/password if supplied
+                diversion:
+                  type: string
+                  description: Diversion header or phone number to apply to outbound calls
+              required: 
+                - name
+      responses:
+        201:
+          description: voip carrier successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Voip Carriers
+      summary: list voip carriers
+      operationId: listVoipCarriers
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of voip carriers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedVoipCarrier'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /VoipCarriers/{VoipCarrierSid}:
+    parameters:
+      - name: VoipCarrierSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Voip Carriers
+      summary: delete a voip carrier
+      operationId: deleteVoipCarrier
+      responses:
+        204:
+          description: voip carrier successfully deleted
+        404:
+          description: voip carrier not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              example:
+                msg: a service provider with active accounts can not be deleted
+              schema:
+                $ref: '#/components/schemas/GeneralError'                
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Voip Carriers
+      summary: retrieve voip carrier
+      operationId: getVoipCarrier
+      responses:
+        200:
+          description: voip carrier found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VoipCarrier'
+        404:
+          description: voip carrier not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - Voip Carriers
+      summary: update voip carrier
+      operationId: updateVoipCarrier
+      parameters:
+      - name: VoipCarrierSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoipCarrier'
+      responses:
+        204:
+          description: voip carrier updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VoipCarrier'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: voip carrier not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /SipGateways:
+    post:
+      tags:
+        - Sip Gateways
+      summary: create sip gateway
+      operationId: createSipGateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                voip_carrier_sid:
+                  type: string
+                  description: voip carrier that provides this gateway
+                  format: uuid
+                ipv4:
+                  type: string
+                port:
+                  type: number
+                is_active:
+                  type: boolean
+                inbound:
+                  type: boolean
+                outbound:
+                  type: boolean
+              required: 
+                - voip_carrier_sid
+                - ipv4
+      responses:
+        201:
+          description: sip gateway successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Sip Gateways
+      summary: list sip gateways
+      operationId: listSipGateways
+      parameters:
+        - in: query
+          name: voip_carrier_sid
+          required: true
+          schema:
+            type: string
+            description: return only the SipGateways operated for this VoipCarrier
+      responses:
+        200:
+          description: list of sip gateways
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SipGateway'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /SipGateways/{SipGatewaySid}:
+    parameters:
+      - name: SipGatewaySid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Sip Gateways
+      summary: delete a sip gateway
+      operationId: deleteSipGateway
+      responses:
+        204:
+          description: sip gateway successfully deleted
+        404:
+          description: sip gateway not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Sip Gateways
+      summary: retrieve sip gateway
+      operationId: getSipGateway
+      responses:
+        200:
+          description: sip gateway found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SipGateway'
+        404:
+          description: sip gateway not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - Sip Gateways
+      summary: update sip gateway
+      operationId: updateSipGateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SipGateway'
+      responses:
+        204:
+          description: sip gateway updated
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: sip gateway not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /SmppGateways:
+    post:
+      tags:
+        - Smpp Gateways
+      summary: create smpp gateway
+      operationId: createSmppGateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                voip_carrier_sid:
+                  type: string
+                  description: voip carrier that provides this gateway
+                  format: uuid
+                ipv4:
+                  type: string
+                port:
+                  type: number
+                netmask:
+                  type: number
+                inbound:
+                  type: boolean
+                outbound:
+                  type: boolean
+                is_primary:
+                  type: boolean
+                use_tls:
+                  type: boolean
+              required: 
+                - voip_carrier_sid
+                - ipv4
+      responses:
+        201:
+          description: smpp gateway successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Smpp Gateways
+      summary: list smpp gateways
+      operationId: listSmppGateways
+      responses:
+        200:
+          description: list of smpp gateways
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SmppGateway'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /SmppGateways/{SmppGatewaySid}:
+    parameters:
+      - name: SmppGatewaySid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Smpp Gateways
+      summary: delete a smpp gateway
+      operationId: deleteSmppGateway
+      responses:
+        204:
+          description: smpp gateway successfully deleted
+        404:
+          description: smpp gateway not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Smpp Gateways
+      summary: retrieve smpp gateway
+      operationId: getSmppGateway
+      responses:
+        200:
+          description: smpp gateway found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmppGateway'
+        404:
+          description: smpp gateway not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - Smpp Gateways
+      summary: update smpp gateway
+      operationId: updateSmppGateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmppGateway'
+      responses:
+        204:
+          description: smpp gateway updated
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: smpp gateway not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError' 
+  /PhoneNumbers:
+    post:
+      tags:
+        - Phone Numbers
+      summary: provision a phone number into inventory from a Voip Carrier
+      operationId: provisionPhoneNumber
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                account_sid:
+                  type: string
+                  format: uuid
+                application_sid:
+                  type: string
+                  format: uuid
+                number:
+                  type: string
+                  description: telephone number
+                voip_carrier_sid:
+                  type: string
+                  format: uuid
+              required: 
+                - number
+                - voip_carrier_sid
+      responses:
+        201:
+          description: phone number successfully provisioned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+              example:
+                msg: invalid telephone number format
+        404:
+          description: voip carrier not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              example:
+                msg: the phone number provided already exists in inventory
+              schema:
+                $ref: '#/components/schemas/GeneralError'                
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Phone Numbers
+      summary: list phone numbers
+      operationId: listProvisionedPhoneNumbers
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of phone numbers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedPhoneNumber'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /PhoneNumbers/{PhoneNumberSid}:
+    parameters:
+      - name: PhoneNumberSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Phone Numbers
+      summary: delete a phone number
+      operationId: deletePhoneNumber
+      responses:
+        204:
+          description: phone number successfully deleted
+        404:
+          description: phone number not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              example:
+                msg: phone number that is assigned to an account may not be deleted
+              schema:
+                $ref: '#/components/schemas/GeneralError'                
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Phone Numbers
+      summary: retrieve phone number
+      operationId: getPhoneNumber
+      responses:
+        200:
+          description: phone number found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneNumber'
+        404:
+          description: phone number not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - Phone Numbers
+      summary: update phone number
+      operationId: updatePhoneNumber
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneNumber'
+      responses:
+        204:
+          description: phone number updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VoipCarrier'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: phone number not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  
+  /ServiceProviders:
+    post:
+      tags:
+        - Service Providers
+      summary: create service provider
+      operationId: createServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: service provider name
+                  example: fastcomms
+                description:
+                  type: string
+                root_domain:
+                  type: string
+                  description: root domain for group of accounts that share a registration hook
+                  example: example.com
+                registration_hook:
+                  $ref: '#/components/schemas/Webhook'
+                ms_teams_fqdn:
+                  type: string
+                  description: SBC domain name for Microsoft Teams
+                  example: contoso.com
+              required: 
+                - name
+      responses:
+        201:
+          description: service provider successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+    get:
+      tags:
+        - Service Providers
+      summary: list service providers
+      operationId: listServiceProviders
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of service providers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedServiceProvider'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /ServiceProviders/{ServiceProviderSid}:
+    parameters:
+    - name: ServiceProviderSid
+      in: path
+      required: true
+      style: simple
+      explode: false
+      schema:
+        type: string
+    delete:
+      tags:
+        - Service Providers
+      summary: delete a service provider
+      operationId: deleteServiceProvider
+      responses:
+        204:
+          description: service provider successfully deleted
+        404:
+          description: service provider not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve service provider
+      operationId: getServiceProvider
+      responses:
+        200:
+          description: service provider found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceProvider'
+        404:
+          description: service provider not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+                
+    put:
+      tags:
+        - Service Providers
+      summary: update service provider
+      operationId: updateServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceProvider'
+      responses:
+        204:
+          description: service provider updated
+        404:
+          description: service provider not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /ServiceProviders/{ServiceProviderSid}/Accounts:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Service Providers
+      summary: get all accounts for a service provider
+      operationId: getServiceProviderAccounts
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: account listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedAccount'
+        403:
+          description: unauthorized
+        404:
+          description: service provider not found
+
+  /ServiceProviders/{ServiceProviderSid}/VoipCarriers:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Service Providers
+      summary: get all carriers for a service provider
+      operationId: getServiceProviderCarriers
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: account listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedVoipCarrier'
+        403:
+          description: unauthorized
+        404:
+          description: service provider not found
+    post:
+      tags:
+        - Service Providers
+      summary: create a carrier
+      operationId: createCarrierForServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoipCarrier'
+      responses:
+        201:
+          description: service provider successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: service provider not found
+  /ServiceProviders/{ServiceProviderSid}/PredefinedCarriers/{PredefinedCarrierSid}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: PredefinedCarrierSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Service Providers
+      summary: add a VoiPCarrier to a service provider based on PredefinedCarrier template
+      operationId: createVoipCarrierFromTemplate
+      responses:
+        201:
+          description:  voip carrier successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials/:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Service Providers
+      summary: create a speech credential for a service provider
+      operationId: addSpeechCredentialForSeerviceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpeechCredential'
+      responses:
+        201:
+          description: speech credential successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: credential not found
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials/{SpeechCredentialSid}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: SpeechCredentialSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Service Providers
+      summary: get a specific speech credential
+      operationId: getSpeechCredential
+      responses:
+        200:
+          description: retrieve speech credentials for a specified account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpeechCredential'
+        404:
+          description: credential not found
+    put:
+      tags:
+        - Service Providers
+      summary: update a speech credential
+      operationId: updateSpeechCredential
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpeechCredentialUpdate'
+      responses:
+        204:
+          description: credential successfully updated
+        404:
+          description: credential not found
+        422:
+          description: credential not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    delete:
+      tags:
+        - Service Providers
+      summary: delete a speech credential
+      operationId: deleteSpeechCredential
+      responses:
+        204:
+          description: credential successfully deleted
+        404:
+          description: credential not found
+  /ServiceProviders/{ServiceProviderSid}/SpeechCredentials/{SpeechCredentialSid}/test:
+    get:
+      tags:
+        - Service Providers
+      summary: test a speech credential
+      operationId: testSpeechCredential
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: SpeechCredentialSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: credential test results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tts:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: 
+                            - success 
+                            - fail
+                            - not tested
+                      reason:
+                        type: string
+                  stt:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: 
+                            - success 
+                            - fail
+                      reason:
+                        type: string
+        404:
+          description: credential not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /ServiceProviders/{ServiceProviderSid}/Limits:
+    post:
+      tags:
+        - Service Providers
+      summary: create a limit for a service provider
+      operationId: addLimitForServiceProvider
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Limits'
+      responses:
+        201:
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: service provider not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve call capacity and other limits from the service provider
+      operationId: getServiceProviderLimits
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: current_contract
+          in: query
+          description: Option to fetch only the current date.
+          required: false
+          schema:
+            type: boolean
+        - name: category
+          in: query
+          description: Category
+          required: false
+          schema:
+            type: string
+        - name: contract_start_date
+          in: query
+          description: Contract start date
+          required: false
+          schema:
+            type: string
+        - name: contract_end_date
+          in: query
+          description: Contract end date
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: service provider limits
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Limits'
+        404:
+          description: service provider not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /ServiceProviders/{ServiceProviderSid}/Limits/{ServiceProviderLimitSid}:
+    put:
+      tags:
+        - Service Providers
+      summary: edit contract limits
+      operationId: putServiceProviderLimits
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uui
+        - name: ServiceProviderLimitSid
+          in: path
+          description: The id of the limit to delete.
+          required: true
+          schema:
+            type: string
+            format: uui
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LimitsPut'
+      responses:
+        201:
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: service provider not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    delete:
+      tags:
+        - Service Providers
+      summary: delete contract limits
+      operationId: deleteServiceProviderLimits
+      parameters:
+        - name: ServiceProviderSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uui
+        - name: ServiceProviderLimitSid
+          in: path
+          description: The id of the limit to delete.
+          required: true
+          schema:
+            type: string
+            format: uui
+      responses:
+        204:
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: service provider not found or limit not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /ServiceProviders/{ServiceProviderSid}/Lcrs:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Service Providers
+      summary: get all Least Cost Routings for a service provider
+      operationId: getServiceProviderLcrs
+      responses:
+        200:
+          description: Least cost routing listing
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Lcr'
+        403:
+          description: unauthorized
+        404:
+          description: service provider not found
+    post:
+      tags:
+        - Service Providers
+      summary: create a Lest cost routing
+      operationId: createLcrForServiceProvider
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: name or Least Cost Routing
+                  example: twilioLcr
+              required:
+                - name
+      responses:
+        201:
+          description: service provider Lcr successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: service provider not found
+  /Accounts/{AccountSid}/Limits:
+    post:
+      tags:
+        - Accounts
+      summary: create a limit for an account
+      operationId: addLimitForAccount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Limits'
+      responses:
+        201:
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Accounts
+      summary: retrieve call capacity and other limits from the account
+      operationId: getAccountLimits
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: current_contract
+          in: query
+          description: Option to fetch only the current date.
+          required: false
+          schema:
+            type: boolean
+        - name: category
+          in: query
+          description: Category
+          required: false
+          schema:
+            type: string
+        - name: contract_start_date
+          in: query
+          description: Contract start date
+          required: false
+          schema:
+            type: string
+        - name: contract_end_date
+          in: query
+          description: Contract end date
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: account limits
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Limits'
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Accounts/{AccountSid}/Limits/{AccountLimitSid}:
+    put:
+      tags:
+        - Accounts
+      summary: edit a limit for an account
+      operationId: putLimitForAccount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: AccountLimitSid
+          in: path
+          description: The id of the limit to update.
+          required: true
+          schema:
+            type: string
+            format: uui
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LimitsPut'
+      responses:
+        201:
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    delete:
+      tags:
+        - Accounts
+      summary: delete limit for an account
+      operationId: deleteLimitForAccount
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: AccountLimitSid
+          in: path
+          description: The id of the limit to update.
+          required: true
+          schema:
+            type: string
+            format: uui
+      responses:
+        204:
+          description: limit successfully created or updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Accounts:
+    post:
+      tags:
+        - Accounts
+      summary: create an account
+      operationId: createAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: account name
+                  example: foobar
+                sip_realm:
+                  type: string
+                  description: sip realm for registration
+                  example: sip.mycompany.com
+                registration_hook:
+                  $ref: '#/components/schemas/Webhook'
+                queue_event_hook:
+                  $ref: '#/components/schemas/Webhook'
+                service_provider_sid:
+                  type: string
+                  format: uuid
+                  example: 85f9c036-ba61-4f28-b2f5-617c23fa68ff
+              required: 
+                - name
+                - service_provider_sid
+      responses:
+        201:
+          description: account successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+      callbacks:
+        onRegistrationAttempt:
+          '{$request.body#/registrationUrl}/auth':
+            post:
+              requestBody:
+                description: |
+                  provides details of the authentication request.  The receiving server is responsible for authenticating the 
+                  request as per [RFC 2617](https://tools.ietf.org/html/rfc2617)
+                content:
+                  application/json:
+                    schema:
+                      required:
+                        - method
+                        - realm
+                        - username
+                        - expires
+                        - nonce
+                        - uri
+                        - response
+                      type: object
+                      properties:
+                        method:
+                          type: string
+                          description: sip request method
+                          example: REGISTER
+                        realm:
+                          type: string
+                          description: sip realm
+                          example: mycompany.com
+                        username:
+                          type: string
+                          description: sip username provided
+                          example: daveh
+                        expires:
+                          type: number
+                          description: expiration requested, in seconds
+                          example: 3600
+                        scheme:
+                          type: string
+                          description: encryption protocol
+                          example: digest
+                        nonce:
+                          type: string
+                          description: nonce value
+                          example: InFriVGWVoKeCckYrTx7wg=="
+                        uri:
+                          type: string
+                          format: uri
+                          description: sip uri in request
+                          example: sip:mycompany.com
+                        algorithm:
+                          type: string
+                          description: encryption algorithm used, default to MD5 if not provided
+                          example: MD5
+                        qop:
+                          type: string
+                          description: qop value
+                          example: auth 
+                        cnonce:
+                          type: string
+                          description: cnonce value
+                          example: 6b8b4567
+                        nc:
+                          type: string
+                          description: nc value
+                          example: 00000001
+                        response:
+                          type: string
+                          description: digest value calculated by the client
+                          example: be641cf7951ff23ab04c57907d59f37d
+              responses:
+                '200':
+                  description: |
+                    Your callback should return this HTTP status code in all cases.
+                    if the request was authenticated and you wish to admit 
+                    the client to the network, this is indicated by setting the 'response' 
+                    attribute in the body to 'ok'
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: string
+                            description: indicates whether the request was successfully authenticated
+                            enum:
+                              - ok
+                              - fail
+                            example: ok
+                          message:
+                            type: string
+                            description: a human-readable message
+                            example: authentication granted
+                          call_hook:
+                            type: string
+                            format: url
+                            description: url of application to invoke when this device places a call
+                          expires:
+                            type: number
+                            description: |
+                              The expires value to grant to the requesting user.
+                              If not provided, the expires value in the request is observed.
+                              If provided, must be less than the requested expires value.
+                          blacklist:
+                            type: number
+                            description: |
+                              If provided, represents a period in seconds during which the source IP 
+                              address should be blacklisted by the platform (0 means forever).
+
+    get:
+      tags:
+        - Accounts
+      summary: list accounts
+      operationId: listAccounts
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedAccount'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /Accounts/{AccountSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    delete:
+      tags:
+        - Accounts
+      summary: delete an account
+      operationId: deleteAccount
+      responses:
+        204:
+          description: account successfully deleted
+        404:
+          description: account not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Accounts
+      summary: retrieve account
+      operationId: getAccount
+      responses:
+        200:
+          description: account found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+    put:
+      tags:
+        - Accounts
+      summary: update account
+      operationId: updateAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Account'
+      responses:
+        204:
+          description: account updated
+        404:
+          description: account not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Accounts/{AccountSid}/WebhookSecret:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: regenerate
+        in: query
+        required: false
+        schema:
+          type: boolean
+    get:
+      tags:
+        - Accounts
+      summary: get webhook signing secret, regenerating if requested
+      operationId: getWebhookSecret
+      responses:
+        200:
+          description: secret
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webhook_secret:
+                    type: string
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /Accounts/{AccountSid}/ApiKeys:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Accounts
+      summary: get all api keys for an account
+      operationId: getAccountApiKeys
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of api keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedApiKey'
+        404:
+          description: account not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /Accounts/{AccountSid}/SipRealms/{SipRealm}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: SipRealm
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      tags:
+        - Accounts
+      summary: add or change the sip realm
+      operationId: createSipRealm
+      responses:
+        204:
+          description: sip_realm updated and DNS entries successfully created
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /Accounts/{AccountSid}/SpeechCredentials:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    post:
+      tags:
+        - Accounts
+      summary: add a speech credential
+      operationId: createSpeechCredential
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpeechCredential'
+      responses:
+        201:
+          description: speech credential successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Accounts
+      summary: retrieve all speech credentials for an account
+      operationId: listSpeechCredentials
+      responses:
+        200:
+          description: retrieve speech credentials for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SpeechCredential'
+        404:
+          description: account not found
+  /Accounts/{AccountSid}/SpeechCredentials/{SpeechCredentialSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: SpeechCredentialSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Accounts
+      summary: get a specific speech credential
+      operationId: getAccountSpeechCredential
+      responses:
+        200:
+          description: retrieve speech credentials for a specified account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpeechCredential'
+        404:
+          description: credential not found
+    put:
+      tags:
+        - Accounts
+      summary: update a speech credential
+      operationId: updateAccountSpeechCredential
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpeechCredentialUpdate'
+      responses:
+        204:
+          description: credential successfully deleted
+        404:
+          description: credential not found
+        422:
+          description: credential not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    delete:
+      tags:
+        - Accounts
+      summary: delete a speech credential
+      operationId: deleteAccountSpeechCredential
+      responses:
+        204:
+          description: credential successfully deleted
+        404:
+          description: credential not found
+  /Accounts/{AccountSid}/SpeechCredentials/{SpeechCredentialSid}/test:
+    get:
+      tags:
+        - Accounts
+      summary: test a speech credential
+      operationId: testAccountSpeechCredential
+      parameters:
+        - name: AccountSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: SpeechCredentialSid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: credential test results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tts:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: 
+                            - success 
+                            - fail
+                            - not tested
+                      reason:
+                        type: string
+                  stt:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: 
+                            - success 
+                            - fail
+                      reason:
+                        type: string
+        404:
+          description: credential not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Accounts/{AccountSid}/RecentCalls:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: page
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: page number of data to retrieve
+      - in: query
+        name: count
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: number of rows to retrieve in each page set
+      - in: query
+        name: days
+        required: false
+        schema:
+          type: number
+          format: integer
+          description: number of days back to retrieve, must be ge 1 and le 30
+      - in: query
+        name: start
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: start date to retrieve
+      - in: query
+        name: end
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: end date to retrieve
+      - in: query
+        name: answered
+        required: false
+        schema:
+          type: string
+          enum:
+            - true
+            - false
+          description: retrieve only answered calls
+      - in: query
+        name: direction
+        required: false
+        schema:
+          type: string
+          enum:
+            - inbound
+            - outbound
+      - in: query
+        name: filter
+        required: false
+        schema:
+          type: string
+        description: Filter value can be caller ID, callee ID or call Sid
+    get:
+      tags:
+        - Accounts
+      summary: retrieve recent calls for an account
+      operationId: listAccountRecentCalls
+      responses:
+        200:
+          description: retrieve recent call records for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: number
+                    format: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: number
+                    format: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: number
+                    format: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          account_sid:
+                            type: string
+                            format: uuid
+                          call_sid:
+                            type: string
+                            format: uuid
+                          from:
+                            type: string
+                          to: 
+                            type: string
+                          answered:
+                            type: boolean
+                          sip_call_id:
+                            type: string
+                          sip_status:
+                            type: number
+                            format: integer
+                          duration:
+                            type: number
+                            format: integer
+                          attempted_at:
+                            type: number
+                            format: integer
+                          answered_at:
+                            type: number
+                            format: integer
+                          terminated_at:
+                            type: number
+                            format: integer
+                          termination_reason:
+                            type: string
+                          host:
+                            type: string
+                          remote_host:
+                            type: string
+                          direction:
+                            type: string
+                            enum:
+                              - inbound
+                              - outbound
+                          trunk:
+                            type: string
+                        required:
+                          - account_sid
+                          - call_sid
+                          - attempted_at
+                          - terminated_at
+                          - answered
+                          - direction
+                          - from 
+                          - to
+                          - sip_status
+                          - duration
+        404:
+          description: account not found
+  /Accounts/{AccountSid}/RecentCalls/{CallId}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Accounts
+      summary: retrieve sip trace detail for a call
+      operationId: getRecentCallTrace
+      responses:
+        200:
+          description: retrieve sip trace data
+          content:
+            application/json:
+              schema:
+                type: object
+        404:
+          description: account or call not found
+  /ServiceProviders/{ServiceProviderSid}/RecentCalls/{CallId}/pcap:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve pcap for a call
+      operationId: getRecentCallTracePcap
+      responses:
+        200:
+          description: retrieve sip trace data
+          content:
+            application/octet-stream:
+              schema:
+                type: object
+        404:
+          description: account or call not found
+  /ServiceProviders/{ServiceProviderSid}/RecentCalls:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: page
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: page number of data to retrieve
+      - in: query
+        name: count
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: number of rows to retrieve in each page set
+      - in: query
+        name: days
+        required: false
+        schema:
+          type: number
+          format: integer
+          description: number of days back to retrieve, must be ge 1 and le 30
+      - in: query
+        name: start
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: start date to retrieve
+      - in: query
+        name: end
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: end date to retrieve
+      - in: query
+        name: answered
+        required: false
+        schema:
+          type: string
+          enum:
+            - true
+            - false
+          description: retrieve only answered calls
+      - in: query
+        name: direction
+        required: false
+        schema:
+          type: string
+          enum:
+            - inbound
+            - outbound
+      - in: query
+        name: from
+        required: false
+        schema:
+          type: string
+        description: calling number to retrieve
+      - in: query
+        name: to
+        required: false
+        schema:
+          type: string
+        description: called number to retrieve
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve recent calls for an account
+      operationId: listRecentCalls
+      responses:
+        200:
+          description: retrieve recent call records for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: number
+                    format: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: number
+                    format: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: number
+                    format: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          service_provider_sid:
+                            type: string
+                            format: uuid
+                          account_sid:
+                            type: string
+                            format: uuid
+                          call_sid:
+                            type: string
+                            format: uuid
+                          from:
+                            type: string
+                          to: 
+                            type: string
+                          answered:
+                            type: boolean
+                          sip_call_id:
+                            type: string
+                          sip_status:
+                            type: number
+                            format: integer
+                          duration:
+                            type: number
+                            format: integer
+                          attempted_at:
+                            type: number
+                            format: integer
+                          answered_at:
+                            type: number
+                            format: integer
+                          terminated_at:
+                            type: number
+                            format: integer
+                          termination_reason:
+                            type: string
+                          host:
+                            type: string
+                          remote_host:
+                            type: string
+                          direction:
+                            type: string
+                            enum:
+                              - inbound
+                              - outbound
+                          trunk:
+                            type: string
+                        required:
+                          - account_sid
+                          - call_sid
+                          - attempted_at
+                          - terminated_at
+                          - answered
+                          - direction
+                          - from 
+                          - to
+                          - sip_status
+                          - duration
+        404:
+          description: account not found
+  /ServiceProviders/{ServiceProviderSid}/RecentCalls/{CallId}:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve sip trace detail for a call
+      operationId: getRecentCallTraceCallId
+      responses:
+        200:
+          description: retrieve sip trace data
+          content:
+            application/json:
+              schema:
+                type: object
+        404:
+          description: service provider or call not found
+  /Accounts/{AccountSid}/RecentCalls/{CallId}/pcap:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: CallId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Accounts
+      summary: retrieve pcap for a call
+      operationId: getAccountRecentCallTracePcap
+      responses:
+        200:
+          description: retrieve sip trace data
+          content:
+            application/octet-stream:
+              schema:
+                type: object
+        404:
+          description: account or call not found
+  /ServiceProviders/{ServiceProviderSid}/Alerts:
+    parameters:
+      - name: ServiceProviderSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: page
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: page number of data to retrieve
+      - in: query
+        name: count
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: number of rows to retrieve in each page set
+      - in: query
+        name: days
+        required: false
+        schema:
+          type: number
+          format: integer
+          description: number of days back to retrieve, must be ge 1 and le 30
+      - in: query
+        name: start
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: start date to retrieve
+      - in: query
+        name: end
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: end date to retrieve
+      - in: query
+        name: alert_type
+        required: false
+        schema:
+          type: string
+          enum:
+            - webhook-failure
+            - webhook-connection-failure
+            - webhook-auth-failure
+            - no-tts
+            - no-stt
+            - tts-failure
+            - stt-failure
+            - no-carrier
+            - call-limit
+            - device-limit
+            - api-limit
+    get:
+      tags:
+        - Service Providers
+      summary: retrieve alerts for a service provider
+      operationId: listAlerts
+      responses:
+        200:
+          description: retrieve alerts for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: number
+                    format: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: number
+                    format: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: number
+                    format: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                            format: date-time
+                          service_provider_sid:
+                            type: string
+                            format: uuid
+                          account_sid:
+                            type: string
+                            format: uuid
+                          alert_type:
+                            type: string
+                          message:
+                            type: string
+                          detail:
+                            type: string
+                        required:
+                          - time
+                          - account_sid
+                          - alert_type
+                          - message
+        404:
+          description: service provider not found
+  /Accounts/{AccountSid}/Alerts:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: page
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: page number of data to retrieve
+      - in: query
+        name: count
+        required: true
+        schema:
+          type: number
+          format: integer
+          description: number of rows to retrieve in each page set
+      - in: query
+        name: days
+        required: false
+        schema:
+          type: number
+          format: integer
+          description: number of days back to retrieve, must be ge 1 and le 30
+      - in: query
+        name: start
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: start date to retrieve
+      - in: query
+        name: end
+        required: false
+        schema:
+          type: string
+          format: date-time
+          description: end date to retrieve
+      - in: query
+        name: alert_type
+        required: false
+        schema:
+          type: string
+          enum:
+            - webhook-failure
+            - webhook-connection-failure
+            - webhook-auth-failure
+            - no-tts
+            - no-stt
+            - tts-failure
+            - stt-failure
+            - no-carrier
+            - call-limit
+            - device-limit
+            - api-limit
+    get:
+      tags:
+       - Accounts
+      summary: retrieve alerts for an account
+      operationId: listAccountAlerts
+      responses:
+        200:
+          description: retrieve alerts for a specified account
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: number
+                    format: integer
+                    description: total number of records in that database that match the filter criteria
+                  batch:
+                    type: number
+                    format: integer
+                    description: total number of records returned in this page set
+                  page:
+                    type: number
+                    format: integer
+                    description: page number that was requested, and is being returned
+                  data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          time:
+                            type: string
+                            format: date-time
+                          account_sid:
+                            type: string
+                            format: uuid
+                          alert_type:
+                            type: string
+                          message:
+                            type: string
+                          detail:
+                            type: string
+                        required:
+                          - time
+                          - account_sid
+                          - alert_type
+                          - message
+        404:
+          description: account not found
+  /Applications:
+    post:
+      tags:
+       - Applications
+      summary: create application
+      operationId: createApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: application name
+                account_sid:
+                  type: string
+                  format: uuid
+                call_hook:
+                  $ref: '#/components/schemas/Webhook'
+                call_status_hook:
+                  $ref: '#/components/schemas/Webhook'
+                messaging_hook:
+                  $ref: '#/components/schemas/Webhook'
+                app_json:
+                   type: string
+                   description: Voice Application Json, call_hook will not be invoked if app_json is provided
+                speech_synthesis_vendor:
+                  type: string
+                speech_synthesis_voice:
+                  type: string
+                speech_recognizer_vendor:
+                  type: string
+                speech_recognizer_language:
+                  type: string
+              required: 
+                - name
+                - account_sid
+                - call_hook
+                - call_status_hook
+      responses:
+        201:
+          description: application successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+       - Applications
+      summary: list applications
+      operationId: listApplications
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of applications
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedApplication'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+
+  /Applications/{ApplicationSid}:
+    parameters:
+      - name: ApplicationSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+       - Applications
+      summary: delete an application
+      operationId: deleteApplication
+      responses:
+        204:
+          description: application successfully deleted
+        404:
+          description: application not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+       - Applications
+      summary: retrieve an application
+      responses:
+        200:
+          description: application found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+        404:
+          description: application not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+       - Applications
+      summary: update application
+      operationId: updateApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Application'
+      responses:
+        204:
+          description: application updated
+        404:
+          description: application not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        
+  
+  /Accounts/{AccountSid}/Calls:
+    post:
+      tags:
+       - Accounts
+      summary: create a call
+      operationId: createCall
+      parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+                - from
+                - to
+              type: object
+              properties:
+                application_sid:
+                  type: string
+                  format: uuid
+                  description: The application to use to control this call.  Either applicationSid or url is required.
+                answerOnBridge:
+                  type: boolean
+                  description: If set to true, the inbound call will ring until the number that was dialed answers the call, and at that point a 200 OK will be sent on the inbound leg.  If false, the inbound call will be answered immediately as the outbound call is placed.
+                  example: false
+                call_hook:
+                  $ref: '#/components/schemas/Webhook'
+                  example: {"url": "https://acme.com/callhook", "method": "POST"}
+                call_status_hook:
+                  $ref: '#/components/schemas/Webhook'
+                  example: {"url": "https://acme.com/status", "method": "POST"}
+                from:
+                  type: string
+                  description: The calling party number
+                  example: "16172375089"
+                fromHost:
+                  type: string
+                  description: The hostname to put in the SIP From header of the INVITE
+                  example: "blf.finotel.com"
+                timeout:
+                  type: integer
+                  description: The number of seconds to wait for call to be answered.  Defaults to 60.
+                  example: 30
+                timeLimit:
+                  type: integer
+                  description: The max length of call in seconds
+                  example: 60
+                tag:
+                  type: object
+                  description: Initial set of customer-supplied metadata to associate with the call (see jambonz 'tag' verb)
+                  example: {"callCount": 10}
+                to:
+                  $ref: '#/components/schemas/Target'
+                  description: Destination for call
+                headers:
+                  type: object
+                  description: The customer SIP headers to associate with the call
+                  example: {"X-Custom-Header": "Hello"}
+      responses:
+        201:
+          description: call successfully created
+          content:
+            application/json:
+              schema:
+                required:
+                  - sid
+                properties:
+                  sid:
+                    type: string
+                    format: uuid
+                    example: 2531329f-fb09-4ef7-887e-84e648214436
+        400:
+          description: bad request
+    get:
+      tags:
+       - Accounts
+      summary: list calls
+      operationId: listCalls
+      parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: direction
+        required: false
+        schema:
+          type: string
+          enum:
+            - inbound
+            - outbound
+        description: call direction to retrieve
+      - in: query
+        name: from
+        required: false
+        schema:
+          type: string
+        description: calling number to retrieve
+      - in: query
+        name: to
+        required: false
+        schema:
+          type: string
+        description: called number to retrieve
+      - in: query
+        name: callStatus
+        required: false
+        schema:
+          type: string
+          enum:
+            - trying
+            - ringing
+            - early-media
+            - in-progress
+            - completed
+            - failed
+            - busy
+            - no-answer
+            - queued
+        description: call status to retrieve
+      responses:
+        200:
+          description: list of calls for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Call'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Accounts/{AccountSid}/Calls/{CallSid}:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: CallSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+       - Accounts
+      summary: delete a call
+      operationId: deleteCall
+      responses:
+        204:
+          description: call successfully deleted
+        404:
+          description: call not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+       - Accounts
+      summary: retrieve a call
+      operationId: getCall
+      responses:
+        200:
+          description: call found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Call'
+        404:
+          description: call not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    post:
+      tags:
+       - Accounts
+      summary: update a call
+      operationId: updateCall
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                call_hook:
+                  $ref: '#/components/schemas/Webhook'
+                child_call_hook:
+                  $ref: '#/components/schemas/Webhook'
+                call_status:
+                  type: string
+                  enum:
+                    - completed
+                    - no-answer
+                conf_mute_status:
+                  type: string
+                  enum:
+                    - mute
+                    - unmute
+                conf_hold_status:
+                  type: string
+                  enum:
+                    - hold
+                    - unhold
+                listen_status:
+                  type: string
+                  enum:
+                    - pause
+                    - silence
+                    - resume
+                mute_status:
+                  type: string
+                  enum:
+                    - mute
+                    - unmute
+                whisper:
+                  $ref: '#/components/schemas/Webhook'
+                sip_request:
+                  type: object
+                  properties:
+                    method:
+                      type: string
+                    content_type:
+                      type: string
+                    content:
+                      type: string
+                    headers:
+                      type: object
+                record: 
+                  type: object
+                  properties:
+                    action:
+                      type: string
+                      enum:
+                      - startCallRecording
+                      - stopCallRecording
+                      - pauseCallRecording
+                      - resumeCallRecording
+                    recordingID:
+                      type: string 
+                    siprecServerURL:
+                      type: string
+      responses:
+        200:
+          description: Accepted
+        202:
+          description: Accepted
+        400:
+          description: bad request
+        404:
+          description: call not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'  
+
+  /Accounts/{AccountSid}/Queues:
+    parameters:
+      - name: AccountSid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: search
+        required: false
+        schema:
+          type: string
+          description: queue name of data to retrieve
+    get:
+      tags:
+        - Accounts
+      summary: retrieve active queues for an account
+      operationId: listQueues
+      responses:
+        200:
+          description: retrieve active queues records for a specified account
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    length:
+                      type: string
+  /Lcrs:
+    post:
+      tags:
+        - Lcrs
+      summary: create a Least Cost Routing
+      operationId: createLcr
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: name or Least Cost Routing
+                  example: twilioLcr
+              required:
+                - name
+      responses:
+        201:
+          description: Least Cost Routing successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Lcrs
+      summary: list least cost routings
+      operationId: listLeastCostRoutings
+      responses:
+        200:
+          description: list of least cost routings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Lcr'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /Lcrs/{LcrSid}:
+    parameters:
+      - name: LcrSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - Lcrs
+      summary: delete a least cost routing
+      operationId: deleteLeastCostRouting
+      responses:
+        204:
+          description: least cost routing successfully deleted
+        404:
+          description: least cost routing not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              example:
+                msg: a service provider with active accounts can not be deleted
+              schema:
+                $ref: '#/components/schemas/GeneralError'                
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - Lcrs
+      summary: retrieve least cost routing
+      operationId: getLeastCostRouting
+      responses:
+        200:
+          description: least cost routing found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lcr'
+        404:
+          description: least cost routing not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - Lcrs
+      summary: update least cost routing
+      operationId: updateLeastCostRouting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lcr'
+      responses:
+        204:
+          description: least cost routing updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lcr'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: least cost routing not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /LcrRoutes:
+    post:
+      tags:
+        - LcrRoutes
+      summary: create a Least Cost Routing Routes
+      operationId: createLcrRoutes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LcrRoute'
+              required:
+                - lcr_sid
+                - regex
+                - priority
+      responses:
+        201:
+          description: Least Cost Routing Route successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - LcrRoutes
+      summary: list least cost routings routes
+      operationId: listLeastCostRoutingRoutes
+      parameters:
+        - in: query
+          name: page
+          required: true
+          schema:
+            type: number
+            format: integer
+            description: page number of data to retrieve
+        - in: query
+          name: limit
+          required: true
+          schema:
+            type: number
+            format: integer
+            enum: [25, 50, 100]
+            description: number of rows to retrieve in each page set
+      responses:
+        200:
+          description: list of least cost routing routes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponsePaginatedLcrRoute'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /LcrRoutes/{LcrRouteSid}:
+    parameters:
+      - name: LcrRouteSid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - LcrRoutes
+      summary: delete a least cost routing route
+      operationId: deleteLeastCostRoutingRoute
+      responses:
+        204:
+          description: least cost routing route successfully deleted
+        404:
+          description: least cost routing route not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              example:
+                msg: a service provider with active accounts can not be deleted
+              schema:
+                $ref: '#/components/schemas/GeneralError'                
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - LcrRoutes
+      summary: retrieve least cost routing route
+      operationId: getLeastCostRoutingRoute
+      responses:
+        200:
+          description: least cost routing route found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LcrRoute'
+        404:
+          description: least cost routing route not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - LcrRoutes
+      summary: update least cost routing route
+      operationId: updateLeastCostRoutingRoute
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LcrRoute'
+      responses:
+        204:
+          description: least cost routing route updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LcrRoute'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: least cost routing route not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /LcrCarrierSetEntries:
+    post:
+      tags:
+        - LcrCarrierSetEntries
+      summary: create a Least Cost Routing Carrier Set Entry
+      operationId: createLcrCarrierSetEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LcrCarrierSetEntry'
+              required:
+                - lcr_route_sid
+                - voip_carrier_sid
+                - priority
+      responses:
+        201:
+          description: Least Cost Routing Carrier Set Entry successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessfulAdd'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - LcrCarrierSetEntries
+      summary: list least cost routings routes
+      operationId: listLeastCostRoutingCarrierSetEntries
+      responses:
+        200:
+          description: list of least cost routing carrier set entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LcrCarrierSetEntry'
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+  /LcrCarrierSetEntries/{LcrCarrierSetEntrySid}:
+    parameters:
+      - name: LcrCarrierSetEntrySid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+    delete:
+      tags:
+        - LcrCarrierSetEntries
+      summary: delete a least cost routing carrier set entry
+      operationId: deleteLeastCostRoutingCarrierSetEntry
+      responses:
+        204:
+          description: least cost routing carrier set entry successfully deleted
+        404:
+          description: least cost routing carrier set entry not found
+        422:
+          description: unprocessable entity
+          content:
+            application/json:
+              example:
+                msg: a service provider with active accounts can not be deleted
+              schema:
+                $ref: '#/components/schemas/GeneralError'                
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    get:
+      tags:
+        - LcrCarrierSetEntries
+      summary: retrieve least cost routing carrier set entry
+      operationId: getLeastCostRoutingCarrierSetEntry
+      responses:
+        200:
+          description: least cost routing carrier set entry found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LcrCarrierSetEntry'
+        404:
+          description: least cost routing carrier set entry not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+    put:
+      tags:
+        - LcrCarrierSetEntries
+      summary: update least cost routing carrier set entry
+      operationId: updateLeastCostRoutingCarrierSetEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LcrCarrierSetEntry'
+      responses:
+        204:
+          description: least cost routing carrier set entry updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LcrCarrierSetEntry'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+        404:
+          description: least cost routing carrier set entry not found
+        500:
+          description: system error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralError'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+  schemas:
+    Login:
+      type: object
+      properties:
+        user_sid: 
+          type: string
+        api_token:
+          type: string
+        change_password:
+          type: boolean
+      required:
+        - user_sid
+    SuccessfulApiKeyAdd:
+      type: object
+      required:
+        - sid
+        - token
+      properties:
+        sid:
+          type: string
+        token:
+          type: string
+      example:
+        sid: 9d26a637-1679-471f-8da8-7150266e1254
+        token: 589cead6-de24-4689-8ac3-08ffaf102811
+    SuccessfulAdd:
+      type: object
+      required:
+        - sid
+      properties:
+        sid:
+          type: string
+      example:
+        sid: 9d26a637-1679-471f-8da8-7150266e1254
+    GeneralError:
+      type: object
+      required:
+        - msg
+      properties:
+        msg:
+          type: string
+      example:
+        msg: specific error detail will be provided here
+    ServiceProvider:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        root_domain:
+          type: string
+        registration_hook:
+          $ref: '#/components/schemas/Webhook'          
+        ms_teams_fqdn:
+          type: string
+        test_number:
+          type: string
+          description: used for inbound testing for accounts on free plan
+        test_application_name:
+          type: string
+          description: name of test application that can be used for new signups
+        test_application_sid:
+          type: string
+          description: identifies test application that can be used for new signups
+      required:
+        - service_provider_sid
+        - name    
+    ResponsePaginatedServiceProvider:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceProvider'
+    VoipCarrier:
+      type: object
+      properties:
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid          
+        e164_leading_plus:
+          type: boolean
+        requires_register:
+          type: boolean
+        register_username:
+          type: string
+        register_sip_realm:
+          type: string
+        register_password:
+          type: string
+        tech_prefix:
+          type: string
+        inbound_auth_username:
+          type: string
+        inbound_auth_password:
+          type: string
+        diversion:
+          type: string
+        is_active:
+          type: boolean
+        smpp_system_id:
+          type: string
+        smpp_password:
+          type: string
+        smpp_inbound_system_id:
+          type: string
+        smpp_inbound_password:
+          type: string
+        smpp_enquire_link_interval:
+          type: number
+          format: integer
+      required:
+        - voip_carrier_sid
+        - name
+    ResponsePaginatedVoipCarrier:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/VoipCarrier'
+    SipGateway:
+      type: object
+      properties:
+        sip_gateway_sid:
+          type: string
+          format: uuid
+        ipv4:
+          type: string
+        port:
+          type: number
+        netmask:
+          type: number
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        inbound:
+          type: boolean
+        outbound:
+          type: boolean
+      required:
+        - sip_gateway_sid
+        - voip_carrier_sid
+        - ipv4
+        - port
+        - netmask
+    SmppGateway:
+      type: object
+      properties:
+        smpp_gateway_sid:
+          type: string
+          format: uuid
+        ipv4:
+          type: string
+        port:
+          type: number
+        netmask:
+          type: number
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        is_primary:
+          type: boolean
+        use_tls:
+          type: boolean
+        inbound:
+          type: boolean
+        outbound:
+          type: boolean
+      required:
+        - smpp_gateway_sid
+        - voip_carrier_sid
+        - ipv4
+        - port
+        - netmask
+    Account:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        sip_realm:
+          type: string
+        registration_hook:
+          $ref: '#/components/schemas/Webhook'          
+        device_calling_application_sid:
+          type: string
+          format: uuid
+        service_provider_sid:
+          type: string
+          format: uuid
+      required:
+        - account_sid
+        - name
+        - service_provider_sid
+    ResponsePaginatedAccount:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/Account'
+    Application:
+      type: object
+      properties:
+        application_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        account_sid:
+          type: string
+          format: uuid
+        call_hook:
+          $ref: '#/components/schemas/Webhook'
+          description: application webhook for inbound voice calls
+        call_status_hook:
+          $ref: '#/components/schemas/Webhook'
+          description: webhhok for reporting call status events
+        messaging_hook:
+          $ref: '#/components/schemas/Webhook'
+          description: application webhook for inbound SMS/MMS
+        speech_synthesis_vendor:
+          type: string
+        speech_synthesis_voice:
+          type: string
+        speech_recognizer_vendor:
+          type: string
+        speech_recognizer_language:
+          type: string
+      required:
+        - application_sid
+        - name
+        - account_sid
+    ResponsePaginatedApplication:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/Application'
+    ApiKey:
+      type: object
+      properties:
+        api_key_sid:
+          type: string
+          format: uuid
+        token:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        service_provider_sid:
+          type: string
+          format: uuid
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        last_used:
+          type: string
+          format: date-time
+      required:
+        - api_key_sid
+        - token
+    ResponsePaginatedApiKey:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKey'    
+    PhoneNumber:
+      type: object
+      properties:
+        phone_number_sid:
+          type: string
+          format: uuid
+        number:
+          type: string
+        voip_carrier_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+      required:
+        - phone_number_sid
+        - number
+        - voip_carrier_sid
+    ResponsePaginatedPhoneNumber:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/PhoneNumber'
+    Registration:
+      type: object
+      properties:
+        registration_sid:
+          type: string
+          format: uuid
+        username:
+          type: string
+        domain:
+          type: string
+        sip_contact:
+          type: string
+        sip_user_agent:
+          type: string
+      required:
+        - registration_sid
+        - username
+        - domain
+        - sip_contact
+    Webhook:
+      type: object
+      description: authentication webhook for registration
+      properties:
+        webhook_sid:
+          type: string
+          format: uuid
+        url:
+          type: string
+          format: url
+        method:
+          type: string
+          enum:
+            - get
+            - post
+        username:
+          type: string
+        password:
+          type: string
+      required:
+        - url
+      example: {"url": "https://acme.com", "method": "POST"}
+    MsTeamsTenant:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        tenant_fqdn:
+          type: string
+      required:
+        - service_provider_sid
+        - tenant_fqdn
+    Call:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        call_id:
+          type: string
+        call_sid:
+          type: string
+          format: uuid
+        call_status:
+          type: string
+          enum:
+            - trying
+            - ringing
+            - alerting
+            - in-progress
+            - completed
+            - busy
+            - no-answer
+            - failed
+            - queued
+        caller_name:
+          type: string
+        direction:
+          type: string
+          enum:
+            - inbound
+            - outbound 
+        duration:
+          type: integer
+        from:
+          type: string
+        originating_sip_trunk_name:
+          type: string
+        parent_call_sid:
+          type: string
+          format: uuid
+        service_url:
+          type: string
+        sip_status:
+          type: integer
+        to:
+          type: string
+      required:
+        - account_sid
+        - call_id
+        - call_sid
+        - call_status
+        - direction
+        - from
+        - service_url
+        - sip_status
+        - to
+    Target:
+      properties:
+        type:
+          type: string
+          enum:
+            - phone
+            - sip
+            - user
+            - teams
+        number:
+          type: string
+        sipUri:
+          type: string
+        tenant:
+          type: string
+          description: Microsoft Teams customer tenant domain name
+        trunk:
+          type: string
+        vmail:
+          type: boolean
+          description: Dial directly into user's voicemail to leave a message
+        overrideTo:
+          type: string
+        name:
+          type: string
+        auth:
+          type: object
+          properties:
+            username:
+              type: string
+            password:
+              type: string
+      required:
+        - type
+      example: {"type": "phone", "number": "+16172375080"}
+    Message:
+      properties:
+        provider:
+          type: string
+        from:
+          type: string
+        to:
+          type: string
+        text:
+          type: string
+        media:
+          type: string
+      required:
+        - from
+        - to
+      example: {"from": "13394445678", "to": "16173333456", "text": "please call when you can"}
+    SpeechCredential:
+      properties:
+        speech_credential_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        vendor:
+          type: string
+          enum:
+            - google
+            - aws
+        service_key:
+          type: string
+        access_key_id:
+          type: string
+        secret_access_key:
+          type: string
+        aws_region:
+          type: string
+        last_used:
+          type: string
+          format: date-time
+        last_tested:
+          type: string
+          format: date-time
+        use_for_tts:
+          type: boolean
+        use_for_stt:
+          type: boolean
+        tts_tested_ok:
+          type: boolean
+        stt_tested_ok:
+          type: boolean
+        riva_server_uri:
+          type: string
+    ResponsePaginatedSpeechCredential:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/SpeechCredential'
+    SpeechCredentialUpdate:
+      properties:
+        use_for_tts:
+          type: boolean
+        use_for_stt:
+          type: boolean
+    UserAndAccountDetail:
+      type: object
+      properties:
+        user:
+          type: object
+          properties:
+            user_sid:
+              type: string
+            name: 
+              type: string
+            email:
+              type: string
+            phone:
+              type: string
+            service_provider_sid:
+              type: string
+            force_change:
+              type: boolean
+            provider:
+              type: string
+            provider_userid:
+              type: string
+            scope:
+              type: string
+            email_validated:
+              type: boolean
+            phone_validated:
+              type: string
+        account:
+          type: object
+          properties:
+            account_sid:
+              type: string
+            sip_realm:
+              type: string
+            service_provider_sid:
+              type: string
+            registration_hook_sid:
+              type: string
+            queue_event_hook_sid:
+              type: string
+            device_calling_application_sid:
+              type: string
+            is_active:
+              type: boolean
+            created_at:
+              type: string
+              format: date-time
+        testapp:
+          type: object
+          properties:
+            application_sid:
+              type: string
+            name:
+              type: string
+            service_provider_sid:
+              type: string
+            account_sid:
+              type: string
+            call_hook_sid:
+              type: string
+            call_status_hook_sid:
+              type: string
+            messaging_hook_sid:
+              type: string
+            speech_synthesis_vendor:
+              type: string
+            speech_synthesis_language:
+              type: string
+            speech_synthesis_voice:
+              type: string
+            speech_recognizer_vendor:
+              type: string
+            speech_recognizer_language:
+              type: string
+        balance:
+          type: object
+          properties:
+            currency:
+              type: string
+              enum:
+                - USD 
+                - EUR
+            balance:
+              type: number
+            last_updated_at:
+              type: string
+              format: date-time
+            created_at:
+              type: string
+              format: date-time
+            last_transaction_id:
+              type: string
+        capacities:
+          type: object
+          properties:
+            effective_start_date:
+              type: string
+              format: date-time
+            effective_end_date:
+              type: string
+              format: date-time
+            limit_sessions:
+              type: integer
+            limit_registrations:
+              type: integer
+        api_keys:
+          type: array
+          items:
+            type: object
+            properties:
+              token:
+                type: string
+              last_used:
+                type: string
+                format: date-time
+              created_at:
+                type: string
+                format: date-time
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              category:
+                type: string
+              quantity:
+                type: string
+              in_starter_set:
+                type: boolean
+              product_sid:
+                type: string
+              effective_start_date:
+                type: string
+                format: date-time
+              effective_end_date:
+                type: string
+                format: date-time
+    UserProfile:
+      type: object
+      properties:
+        user_sid: 
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        service_provider_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        account_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        is_active:
+          type: boolean
+          description: indicates whether account is active
+          example: true
+        name:
+          type: string
+          description: full user name
+          example: Dave Horton
+        email:
+          type: string
+          description: email associated with user
+          example: daveh@drachtio.org
+        phone:
+          type: string
+          description: phone associated with user
+        provider:
+          type: string
+          description: authentication provider
+          enum:
+            - github
+            - google
+            - local
+          example: github
+        scope:
+          type: string
+          description: scope of user permissions
+          enum:
+            - read-only
+            - read-write
+          example: read-write
+        email_validated:
+          type: boolean
+          description: indicates whether user has validated their email address
+          example: true
+        phone_validated:
+          type: boolean
+          description: indicates whether user has validated their mobile phone
+          example: true
+        tutorial_completion:
+          type: number
+          description: bitmask indicating which tutorials have been completed
+          example: 1
+        jwt:
+          type: string
+          description: json web token to be used as bearer token in API requests
+      required:
+        - user_sid
+        - provider
+        - name
+        - email
+        - scope
+        - account_validated
+        - pristine
+        - jwt
+        - is_active
+    ResponsePaginatedUserProfile:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/UserProfile'
+    UserCreate:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        account_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        is_active:
+          type: boolean
+          description: indicates whether account is active
+          example: true
+        name:
+          type: string
+          description: full user name
+          example: Dave Horton
+        email:
+          type: string
+          description: email associated with user
+          example: daveh@drachtio.org
+        phone:
+          type: string
+          description: phone associated with user
+        initial_password:
+          type: string
+          example: abc123!
+      required:
+        - name
+        - email
+        - is_active
+        - force_change
+        - initial_password
+    UserUpdate:
+      type: object
+      properties:
+        service_provider_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        account_sid:
+          type: string
+          example: a5bce31e-a028-45cd-94c4-f121b72fec61
+        is_active:
+          type: boolean
+          description: indicates whether account is active
+          example: true
+        name:
+          type: string
+          description: full user name
+          example: Dave Horton
+        email:
+          type: string
+          description: email associated with user
+          example: daveh@drachtio.org
+        phone:
+          type: string
+          description: phone associated with user
+        new_password:
+          type: string
+          example: abc123!
+    Charge:
+      type: object
+      properties:
+        charge_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        billed_at:
+          type: string
+          format: date-time
+        billed_activity:
+          type: string
+          enum:
+            - inbound-call
+            - outbound-call
+            - inbound-sms
+            - outbound-sms
+            - inbound-mms
+            - outbound-mms
+            - tts
+            - stt
+        call_billing_record_sid:
+          type: string
+          format: uuid
+        message_record_sid:
+          type: string
+          format: uuid
+        call_secs_billed:
+          type: number
+          format: integer
+        tts_chars_billed:
+          type: number
+          format: integer
+        stt_secs_billed:
+          type: number
+          format: integer
+        amount_charged:
+          type: number
+          format: double
+      required:
+        - account_sid
+        - billed_activity
+        - amount_charged
+    RecentCalls:
+      type: object
+      properties:
+        account_sid:
+          type: string
+          format: uuid
+        call_sid:
+          type: string
+          format: uuid
+        from:
+          type: string
+        to: 
+          type: string
+        answered:
+          type: boolean
+        sip_call_id:
+          type: string
+        sip_status:
+          type: number
+          format: integer
+        duration:
+          type: number
+          format: integer
+        attempted_at:
+          type: number
+          format: integer
+        answered_at:
+          type: number
+          format: integer
+        terminated_at:
+          type: number
+          format: integer
+        termination_reason:
+          type: string
+        host:
+          type: string
+        remote_host:
+          type: string
+        direction:
+          type: string
+          enum:
+            - inbound
+            - outbound
+        trunk:
+          type: string
+      required:
+        - account_sid
+        - call_sid
+        - attempted_at
+        - terminated_at
+        - answered
+        - direction
+        - from 
+        - to
+        - sip_status
+        - duration
+    Alert:
+      type: object
+      properties:
+        alert_sid:
+          type: string
+          format: uuid
+        call_sid:
+          type: string
+          format: uuid
+        account_sid:
+          type: string
+          format: uuid
+        application_sid:
+          type: string
+          format: uuid
+        occurred_at:
+          type: string
+          format: date-time
+        alert_type:
+          type: string
+          enum:
+          - webhook-failed
+          - bad-application-syntax
+          - speech-operation-failed
+          - limit-exceeded
+        details:
+          type: string
+      required:
+        - alert_sid
+        - account_sid
+        - occurred_at
+        - alert_type
+    Product:
+      type: object
+      properties:
+        product_sid:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        unit_label:
+          type: string
+        category:
+          type: string
+      required:
+        - product_sid
+        - name
+        - unit_label
+        - category
+    PredefinedCarrier:
+      type: object
+      properties:
+        predefined_carrier_sid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        requires_static_ip:
+          type: boolean
+        e164_leading_plus:
+          type: boolean
+        requires_register:
+          type: boolean
+        register_username:
+          type: string
+        register_sip_realm:
+          type: string
+        register_password:
+          type: string
+        register_from_user:
+          type: string
+        register_from_domain:
+          type: string
+        register_public_ip_in_contact:
+          type: boolean
+        tech_prefix:
+          type: string
+        inbound_auth_username:
+          type: string
+        inbound_auth_password:
+          type: string
+        diversion:
+          type: string
+      required:
+        - predefined_carrier_sid
+        - name
+        - requires_static_ip
+        - e164_leading_plus
+        - requires_register
+    Limits:
+      type: object
+      properties:
+        category:
+          type: string
+          enum:
+            - voice_call_session
+            - voice_call_minutes
+            - api_limit
+            - devices
+          example: voice_call_session
+        quantity:
+          type: number
+          example: 10
+        contract_quantity:
+          type: number
+          example: 5
+        contract_start_date:
+          type: string
+          example: '2023-01-01'
+        contract_end_date:
+          type: string
+          example: '2023-12-31'
+        contract_renew:
+          type: boolean
+          example: true
+    LimitsPut:
+      type: object
+      properties:
+        quantity:
+          type: number
+          example: 10
+        contract_quantity:
+          type: number
+          example: 5
+        contract_start_date:
+          type: string
+          example: '2023-01-01'
+        contract_end_date:
+          type: string
+          example: '2023-12-31'
+        contract_renew:
+          type: boolean
+          example: true
+    Lcr:
+      type: object
+      properties:
+        name:
+          type: string
+          example: twilioLcr
+        default_carrier_set_entry_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      required:
+        - name
+    LcrRoute:
+      type: object
+      properties:
+        lcr_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        regex:
+          type: string
+          description: out going call Phone number regex
+          example: 1*
+        priority:
+          type: number
+          example: 1
+        description:
+          type: string
+          example: this is example description
+      required:
+        - lcr_sid
+        - regex
+        - priority    
+    ResponsePaginatedLcrRoute:
+      type: object
+      properties:
+        total_items:
+          type: number
+          format: integer
+          description: total number of records in that database that match the filter criteria
+          example: 26
+        total_pages:
+          type: number
+          format: integer
+          description: total number of available pages
+          example: 2
+        page:        
+          type: number
+          format: integer
+          description: page number that was requested, and is being returned
+          example: 1
+        data: 
+          type: array
+          items:
+            $ref: '#/components/schemas/LcrRoute'
+    
+    LcrCarrierSetEntry:
+      type: object
+      properties:
+        workload:
+          type: number
+          example: 90
+          description: traffic distribution value
+        lcr_route_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        voip_carrier_sid:
+          type: string
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        priority:
+          type: number
+          example: 1
+      required:
+      - lcr_route_sid
+      - voip_carrier_sid
+      - priority
+
+security:
+  - bearerAuth: []

--- a/lib/utils/validate-query.js
+++ b/lib/utils/validate-query.js
@@ -1,0 +1,27 @@
+const { DbErrorBadRequest } = require('../utils/errors');
+
+const validateQuery = (query) => {
+  const { page = 1, limit = 25 } = query || {};
+
+  query.page = Number(page);
+  query.limit = Number(limit);
+
+  if (query.page < 1) {
+    throw new DbErrorBadRequest('invalid "page" query parameter');
+  }
+
+  switch (query.limit) {
+    case 25:
+    case 50:
+    case 100:
+      break;
+    default:
+      throw new DbErrorBadRequest('invalid "limit" query parameter');
+  }
+
+  return true;
+};
+
+module.exports = {
+  validateQuery
+};


### PR DESCRIPTION
Improved by adding pagination capabilities to api-server API

- [x] The feature can be enabled via `VG_PAGINATION: "true"`
- [x] users SP
- [x] users account
- [x] users admin
- [x] accounts
- [x] accounts - api_keys
- [x] accounts - applications
- [x] accounts - voip carriers
- [x] applications 
- [x] service_providers
- [x] service_providers - voip carriers
- [x] service_providers - phone numbers
- [X] service_providers - applications
- [X] service_providers - accounts
- [X] service_providers - api_keys
- [X] LCR routes
- [x] Added new swagger-pagination file 

# How to test

Please describe the individual steps on how a peer can test your change.

Precondition: Run api-server locally, set `PAGINATION: "true"`
1. Login via  `{{base_url}}/v1/login`
2. Copy the `token` for all upcoming requests
3. Bearer <token>



```
GET 

{{base_url}}/v1/Accounts?limit=25&page=1
{{base_url}}/v1/Accounts/:account_sid/ApiKeys?limit=25&page=1
{{base_url}}/v1/Accounts/:account_sid/Applications?limit=25&page=1
{{base_url}}/v1/Accounts/:account_sid/VoipCarriers?limit=2&page=1

{{base_url}}/v1/Applications?limit=25&page=1

{{base_url}}/v1/PhoneNumbers?limit=25&page=1

{{base_url}}/v1/lcrs?limit=25&page=1
{{base_url}}/v1/LcrRoutes?limit=25&page=1&lcr_sid=<lcr_sid>

{{base_url}}/v1/ServiceProviders?limit=25&page=1
{{base_url}}/v1/ServiceProviders/:serviceProviderSid/Accounts?limit=25&page=1
{{base_url}}/v1/ServiceProviders/:serviceProviderSid/ApiKeys?limit=25&page=1
{{base_url}}/v1/ServiceProviders/:serviceProviderSid/Applications?limit=25&page=1
{{base_url}}/v1/ServiceProviders/:serviceProviderSid/PhoneNumbers?limit=25&page=1
{{base_url}}/v1/ServiceProviders/:serviceProviderSid/VoipCarriers?limit=25&page=1

{{base_url}}/v1/Users?limit=25&page=1

{{base_url}}/v1/VoipCarriers?limit=25&page=1

{{base_url}}/swagger
```
