### PR TITLE
Reject old JWT tokens

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -31,6 +31,11 @@ function makeStrategy(logger) {
               logger.info('jwt invalidated after logout');
               return done(null, false);
             }
+            /* Reject the request if we receive an old token */
+            if (result !== token) {
+              logger.info('jwt was invalidated after login by another session');
+              return done(null, false);
+            }
           } catch (error) {
             debug(err);
             logger.info({err}, 'Error checking redis for jwt');


### PR DESCRIPTION
This PR fixes an issue - where a previous token could be used for login.

How to reproduce:
1. Call `/v1`/login` 
2. use the token A to e.g `/v1/Users/me`
3. call `/v1/login` again 
4. call  `/v1`/login`  with token A

Expected: then token A is no longer valid - since there is a newer one. Only one active token should be allowed

Actual: You can login with all the tokens as long as there is a valid one in redis
