### PR TITLE
fix cannot send multipart to aws due to min size

### DIFF
--- a/lib/record/s3-multipart-upload-stream.js
+++ b/lib/record/s3-multipart-upload-stream.js
@@ -16,7 +16,7 @@ class S3MultipartUploadStream extends Writable {
     this.partNumber = 1;
     this.multipartETags = [];
     this.buffer = Buffer.alloc(0);
-    this.minPartSize = 2 * 1024 * 1024; // 5 MB
+    this.minPartSize = 5 * 1024 * 1024; // 5 MB
     this.s3 = new S3Client(opts.bucketCredential);
     this.metadata = opts.metadata;
   }


### PR DESCRIPTION
{"level":50,"time":1714697414598,"pid":1761029,"hostname":"ip-10-0-52-68","error":{"name":"EntityTooSmall","$fault":"client","$metadata":{"httpStatusCode":400,"requestId":"VZXWWJPE84YD4DHY","extendedRequestId":"HwOWQ467l7OFeflYu7E60wUF6ueG6uK03ac5OXl921i6/DRQcOdjH6qxD2GsHWnFUlNjHu8q/jA=","attempts":1,"totalRetryDelay":0},"Code":"EntityTooSmall","ProposedSize":"2097216","MinSizeAllowed":"5242880","PartNumber":"1","ETag":"8304bd8aa6e036965a55371c52227a95","RequestId":"VZXWWJPE84YD4DHY","HostId":"HwOWQ467l7OFeflYu7E60wUF6ueG6uK03ac5OXl921i6/DRQcOdjH6qxD2GsHWnFUlNjHu8q/jA=","message":"Your proposed upload is smaller than the minimum allowed size"},"msg":"pipeline error, cannot upload data to storage"}


AWS S3 uploader is spliting 2MB per multipart that is rejected by AWS, minimun is 5MB