### PR TITLE
recent-calls single call record pull

### DIFF
--- a/lib/routes/api/recent-calls.js
+++ b/lib/routes/api/recent-calls.js
@@ -165,6 +165,31 @@ router.get('/:call_sid/record/:year/:month/:day/:format', async(req, res) => {
   }
 });
 
+router.get('/call/:call_sid', async(req, res) => {
+  const { account_sid, call_sid } = req.params;
+  const { logger, queryCdrs } = req.app.locals;
+
+  try {
+    logger.debug('GET /call/:call_sid');
+    const account_sid = parseAccountSid(req.originalUrl);
+    const data = await queryCdrs({
+      account_sid,
+      filter: call_sid,
+      page: 1,
+      page_size: 1
+    });
+
+    if (!data || data.data.length === 0) {
+      return res.status(404).json({ message: 'Call not found' });
+    }
+
+    res.status(200).json(data.data[0]);
+  } catch (err) {
+    logger.error({ err }, `Error retrieving call information for account_sid: ${account_sid}, call_sid: ${call_sid}`);
+    res.sendStatus(500);
+  }
+});
+
 router.delete('/:call_sid/record/:year/:month/:day/:format', async(req, res) => {
   const {logger} = req.app.locals;
   const {call_sid, year, month, day, format} = req.params;


### PR DESCRIPTION
URL: GET {{base_url}}/Accounts/{{account_sid}}/RecentCalls/call/{{call_sid}}

Sample response : 
```json
{
    "attempted_at": "2024-08-10T21:29:29.082Z",
    "account_sid": "***",
    "answered": true,
    "answered_at": "2024-08-10T21:29:42.174Z",
    "application_sid": "**",
    "call_sid": "*****",
    "direction": "outbound",
    "duration": 30,
    "from": "*****",
    "host": "xx.xxx.xxx.xx",
    "recording_url": "/Accounts/******/RecentCalls/*****/record/2024/08/10/mp3",
    "remote_host": "*******",
    "service_provider_sid": "*****",
    "sip_callid": "****",
    "sip_status": 200,
    "terminated_at": "2024-08-10T21:30:12.363Z",
    "termination_reason": "caller hungup",
    "to": "******",
    "trace_id": "****",
    "trunk": "Twilio"
}
```