### PR TITLE
fix voip_carrier api 

### DIFF
--- a/lib/routes/api/voip-carriers.js
+++ b/lib/routes/api/voip-carriers.js
@@ -73,10 +73,12 @@ decorate(router, VoipCarrier, ['add', 'update', 'delete'], preconditions);
 /* list */
 router.get('/', async(req, res) => {
   const logger = req.app.locals.logger;
+  const {lookupAccountBySid} = req.app.locals;
+  const account = req.user.service_provider_sid ? req.user : await lookupAccountBySid(req.user.account_sid);
   try {
     const results = req.user.hasAdminAuth ?
       await VoipCarrier.retrieveAll(req.user.hasAccountAuth ? req.user.account_sid : null) :
-      await VoipCarrier.retrieveAllForSP(req.user.service_provider_sid);
+      await VoipCarrier.retrieveAllForSP(account.service_provider_sid);
 
     if (req.user.hasScope('account')) {
       return res.status(200).json(results.filter((c) => c.account_sid === req.user.account_sid || !c.account_sid));


### PR DESCRIPTION
fetch voip carriers where api key doesn't have the service_provdier_sid,

uses an existing method in dbHelpers so no new function required.

fixes #409 