### PR TITLE
fix the creds test and return correct error

### DIFF
--- a/lib/utils/speech-utils.js
+++ b/lib/utils/speech-utils.js
@@ -362,14 +362,14 @@ const testRimelabs = async(logger, synthAudio, credentials) => {
       {
         vendor: 'rimelabs',
         credentials,
-        language: 'en-US',
+        language: 'eng',
         voice: 'amber',
         text: 'Hi there and welcome to jambones!',
         renderForCaching: true
       }
     );
   } catch (err) {
-    logger.info({err}, 'synth Playht returned error');
+    logger.info({err}, 'synth rimelabs returned error');
     throw err;
   }
 };


### PR DESCRIPTION
The webui test of rime labs credentials was failing as we specify the wron language format, also the error message contained the wrong vendor name