### PR TITLE
Add Aura-2 Voices

### DIFF
--- a/lib/utils/speech-data/tts-model-deepgram.js
+++ b/lib/utils/speech-data/tts-model-deepgram.js
@@ -1,68 +1,320 @@
 module.exports = [
   {
+    locale: 'en-ph',
+    localeName: 'English (PH)',
+    name: 'Amalthea English (PH) Female Aura-2',
+    value: 'aura-2-amalthea-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Andromeda English (US) Female Aura-2',
+    value: 'aura-2-andromeda-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Apollo English (US) Male Aura-2',
+    value: 'aura-2-apollo-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Arcas English (US) Male Aura-2',
+    value: 'aura-2-arcas-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Aries English (US) Male Aura-2',
+    value: 'aura-2-aries-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Asteria English (US) Female Aura-2',
+    value: 'aura-2-asteria-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Athena English (US) Female Aura-2',
+    value: 'aura-2-athena-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Atlas English (US) Male Aura-2',
+    value: 'aura-2-atlas-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Aurora English (US) Female Aura-2',
+    value: 'aura-2-aurora-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Callista English (US) Female Aura-2',
+    value: 'aura-2-callista-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Cora English (US) Female Aura-2',
+    value: 'aura-2-cora-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Cordelia English (US) Female Aura-2',
+    value: 'aura-2-cordelia-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Delia English (US) Female Aura-2',
+    value: 'aura-2-delia-en'
+  },
+  {
+    locale: 'en-gb',
+    localeName: 'English (GB)',
+    name: 'Draco English (GB) Male Aura-2',
+    value: 'aura-2-draco-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Electra English (US) Female Aura-2',
+    value: 'aura-2-electra-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Harmonia English (US) Female Aura-2',
+    value: 'aura-2-harmonia-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Helena English (US) Female Aura-2',
+    value: 'aura-2-helena-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Hera English (US) Female Aura-2',
+    value: 'aura-2-hera-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Hermes English (US) Male Aura-2',
+    value: 'aura-2-hermes-en'
+  },
+  {
+    locale: 'en-au',
+    localeName: 'English (AU)',
+    name: 'Hyperion English (AU) Male Aura-2',
+    value: 'aura-2-hyperion-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Iris English (US) Female Aura-2',
+    value: 'aura-2-iris-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Janus English (US) Female Aura-2',
+    value: 'aura-2-janus-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Juno English (US) Female Aura-2',
+    value: 'aura-2-juno-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Jupiter English (US) Male Aura-2',
+    value: 'aura-2-jupiter-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Luna English (US) Female Aura-2',
+    value: 'aura-2-luna-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Mars English (US) Male Aura-2',
+    value: 'aura-2-mars-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Minerva English (US) Female Aura-2',
+    value: 'aura-2-minerva-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Neptune English (US) Male Aura-2',
+    value: 'aura-2-neptune-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Odysseus English (US) Male Aura-2',
+    value: 'aura-2-odysseus-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Ophelia English (US) Female Aura-2',
+    value: 'aura-2-ophelia-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Orion English (US) Male Aura-2',
+    value: 'aura-2-orion-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Orpheus English (US) Male Aura-2',
+    value: 'aura-2-orpheus-en'
+  },
+  {
+    locale: 'en-gb',
+    localeName: 'English (GB)',
+    name: 'Pandora English (GB) Female Aura-2',
+    value: 'aura-2-pandora-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Phoebe English (US) Female Aura-2',
+    value: 'aura-2-phoebe-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Pluto English (US) Male Aura-2',
+    value: 'aura-2-pluto-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Saturn English (US) Male Aura-2',
+    value: 'aura-2-saturn-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Selene English (US) Female Aura-2',
+    value: 'aura-2-selene-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Thalia English (US) Female Aura-2',
+    value: 'aura-2-thalia-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Theia English (US) Female Aura-2',
+    value: 'aura-2-theia-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Vesta English (US) Female Aura-2',
+    value: 'aura-2-vesta-en'
+  },
+  {
+    locale: 'en-us',
+    localeName: 'English (US)',
+    name: 'Zeus English (US) Male Aura-2',
+    value: 'aura-2-zeus-en'
+  },
+  {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Asteria English (US) Female',
+    name: 'Asteria English (US) Female Aura-1',
     value: 'aura-asteria-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Luna English (US) Female',
+    name: 'Luna English (US) Female Aura-1',
     value: 'aura-luna-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Stella English (US) Female',
+    name: 'Stella English (US) Female Aura-1',
     value: 'aura-stella-en'
   },
   {
     locale: 'en-GB',
     localeName: 'English (UK)',
-    name: 'Stella English (UK) Female',
+    name: 'Stella English (UK) Female Aura-1',
     value: 'aura-athena-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Hera English (US) Female',
+    name: 'Hera English (US) Female Aura-1',
     value: 'aura-hera-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Orion English (US) Male',
+    name: 'Orion English (US) Male Aura-1',
     value: 'aura-orion-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Arcas English (US) Male',
+    name: 'Arcas English (US) Male Aura-1',
     value: 'aura-arcas-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Perseus English (US) Male',
+    name: 'Perseus English (US) Male Aura-1',
     value: 'aura-perseus-en'
   },
   {
     locale: 'en-IE',
     localeName: 'English (Ireland)',
-    name: 'Angus English (Ireland) Male',
+    name: 'Angus English (Ireland) Male Aura-1',
     value: 'aura-angus-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Orpheus English (US) Male',
+    name: 'Orpheus English (US) Male Aura-1',
     value: 'aura-orpheus-en'
+  },
+  {
+    locale: 'en-gb',
+    localeName: 'English (US)',
+    name: 'Helios English (GB) Male Aura-1',
+    value: 'aura-helios-en'
   },
   {
     locale: 'en-US',
     localeName: 'English (US)',
-    name: 'Zeus English (US) Male',
+    name: 'Zeus English (US) Male Aura-1',
     value: 'aura-zeus-en'
   },
 ];


### PR DESCRIPTION
fixes #422 
Added an additional field to the lable, `Aura-1` or `Aura-2` as Deepgram has some voices with both models

Also one missing Aura-1 voice, Helios
![image](https://github.com/user-attachments/assets/14ad46b4-4882-4633-a37c-7e90596f6c77)
