### PR TITLE
remove pino.destination

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,6 +2,6 @@ const opts = {
   level: process.env.JAMBONES_LOGLEVEL || 'info'
 };
 const pino = require('pino');
-const logger = pino(opts, pino.destination(1, {sync: false}));
+const logger = pino(opts);
 
 module.exports = logger;


### PR DESCRIPTION
the issue is with pino.destination and pm2 cluster mode, just setting to sync does not fix the issue.

By removing this config we are using the default pino settings which is still to log to stdOut so the `1` is redundant
BUt we are moving from async to sync logging, however my research says that this is preferable when logging to stdOut as there is no performance differnces if pino isn't writing to a file and it can cause logs to appear out of order

**Problems with Async stdout Logging:**
- Process exit issues: Async writes might not complete before process shutdown
- Log capture interference: PM2, Docker, systemd, and other process managers expect synchronous stdout
- Race conditions: Log messages can arrive out of order or get lost
- Buffering issues: Async writes use internal buffers that can cause delays or loss

**Benefits of Sync stdout Logging:**
- Immediate output: Logs appear instantly in PM2/Docker/system logs
- Guaranteed delivery: No risk of losing logs on process exit
- Proper ordering: Messages appear in correct sequence
- Better debugging: Real-time log visibility

I've tested this on my server and it does indeed solve the loging to the correct pm2 log, I've not noticed any performance difference either but this is a server under very minimal load.
I'd like to try this patch on jambonz.cloud for a few hours and see if it makes any difference to the server load before we merge it.