### PR TITLE
check for whitespace in gateways and phone numbers

### DIFF
--- a/lib/routes/api/phone-numbers.js
+++ b/lib/routes/api/phone-numbers.js
@@ -13,6 +13,7 @@ const preconditions = {
 };
 const sysError = require('../error');
 const { parsePhoneNumberSid } = require('./utils');
+const hasWhitespace = (str) => /\s/.test(str);
 
 
 /* check for required fields when adding */
@@ -28,6 +29,7 @@ async function validateAdd(req) {
     }
 
     if (!req.body.number) throw new DbErrorBadRequest('number is required');
+    if (hasWhitespace(req.body.number)) throw new DbErrorBadRequest('number cannot contain whitespace');
     const formattedNumber = e164(req.body.number);
     req.body.number = formattedNumber;
   } catch (err) {

--- a/lib/routes/api/sip-gateways.js
+++ b/lib/routes/api/sip-gateways.js
@@ -6,6 +6,7 @@ const decorate = require('./decorate');
 const sysError = require('../error');
 const net = require('net');
 
+const hasWhitespace = (str) => /\s/.test(str);
 const checkUserScope = async(req, voip_carrier_sid) => {
   const {lookupCarrierBySid} = req.app.locals;
   if (!voip_carrier_sid) {
@@ -59,6 +60,9 @@ const validate = async(req, sid) => {
     parseInt(netmask) < process.env.JAMBONZ_MIN_GATEWAY_NETMASK) {
     throw new DbErrorBadRequest(
       `netmask required to have value equal or greater than ${process.env.JAMBONZ_MIN_GATEWAY_NETMASK}`);
+  }
+  if (hasWhitespace(ipv4)) {
+    throw new DbErrorBadRequest('Gateway must not contain whitespace');
   }
   if (inbound && !net.isIPv4(ipv4)) {
     throw new DbErrorBadRequest('Inbound gateway must be IPv4 address');


### PR DESCRIPTION
adds a check for whitespace in sip gateways and phone numbers which is a common support problem and hard to diagnose 

There is a separate issue with the web app not surfacing these errors for SIP gateways (along with the existing validation failures) that I have raised as https://github.com/jambonz/jambonz-webapp/issues/544

But the phone number validation is tested and working properly, and this could be merged then awaiting fix of the web app

fixes #364 