### PR TITLE
Fix API for Carriers & SIP Gateways

### DIFF
--- a/lib/routes/api/accounts.js
+++ b/lib/routes/api/accounts.js
@@ -161,7 +161,9 @@ router.post('/:sid/VoipCarriers', async(req, res) => {
   try {
     const account_sid = parseAccountSid(req);
     await validateRequest(req, account_sid);
-    assert(payload.service_provider_sid, 'service_provider_sid is required');
+    // Set the service_provder_sid to the relevent value for the account
+    const account = await Account.retrieve(req.user.account_sid);
+    payload.service_provider_sid = account[0].service_provider_sid;
 
     logger.debug({payload}, 'POST /:sid/VoipCarriers');
     const uuid = await VoipCarrier.make({

--- a/lib/routes/api/accounts.js
+++ b/lib/routes/api/accounts.js
@@ -161,6 +161,7 @@ router.post('/:sid/VoipCarriers', async(req, res) => {
   try {
     const account_sid = parseAccountSid(req);
     await validateRequest(req, account_sid);
+    assert(payload.service_provider_sid, 'service_provider_sid is required');
 
     logger.debug({payload}, 'POST /:sid/VoipCarriers');
     const uuid = await VoipCarrier.make({

--- a/lib/routes/api/service-providers.js
+++ b/lib/routes/api/service-providers.js
@@ -46,9 +46,15 @@ async function validateRetrieve(req) {
       return;
     }
 
-    if (req.user.hasScope('service_provider') || req.user.hasScope('account')) {
+    if (req.user.hasScope('service_provider')) {
       if (service_provider_sid === req.user.service_provider_sid) return;
     }
+
+    if (req.user.hasScope('account')) {
+      const results = await Account.retrieve(req.user.account_sid);
+      if (service_provider_sid === results[0].service_provider_sid) return;
+    }
+
 
     throw new DbErrorForbidden('insufficient permissions');
   } catch (error) {

--- a/lib/routes/api/sip-gateways.js
+++ b/lib/routes/api/sip-gateways.js
@@ -18,8 +18,7 @@ const checkUserScope = async(req, voip_carrier_sid) => {
     const carrier = await lookupCarrierBySid(voip_carrier_sid);
     if (!carrier) throw new DbErrorBadRequest('invalid voip_carrier_sid');
 
-    if ((!carrier.service_provider_sid || carrier.service_provider_sid === req.user.service_provider_sid) &&
-      (!carrier.account_sid || carrier.account_sid === req.user.account_sid)) {
+    if (!carrier.account_sid || carrier.account_sid === req.user.account_sid) {
 
       if (req.method !== 'GET' && !carrier.account_sid) {
         throw new DbErrorForbidden('insufficient privileges');


### PR DESCRIPTION
Fixes #491 

Multiple related issues resolved with this, 
I have now tested the API endpoints used by the WebUI and these fixes enable these to be used with an API key, both Account and Service Provider level where appropriate.

Will update API docs to only list these API endpoints

## Service Provider Account:

**Get All Carriers for a Service Provider**
`GET v1/ServiceProviders/[SERVICE_PROVIDER_SID]/VoipCarriers`

**Get Carriers for an Account as a Service Provider**
`GET v1/ServiceProviders/[SERVICE_PROVIDER_SID]/VoipCarriers?account_sid=[ACCOUNT_SID]`

**Create a Carrier for an Account**
`POST v1/ServiceProviders/[SERVICE_PROVIDER_SID]/VoipCarriers`
(Body must contain account_sid & service_provider_sid)

**Create a shared carrier for a Service Provider** 
`POST v1/ServiceProviders/[SERVICE_PROVIDER_SID]/VoipCarriers`
(Body must contain service_provider_sid)

## User Account:

**Get Carriers for an Account**
`GET v1/ServiceProviders/[SERVICE_PROVIDER_SID]/VoipCarriers`

**Create a Carrier for an Account**
`POST v1/Accounts/[ACCOUNT_SID]/VoipCarriers`
