### PR TITLE
Fix high CPU during call recording: optimize multipart upload buffering

### DIFF
--- a/lib/record/s3-multipart-upload-stream.js
+++ b/lib/record/s3-multipart-upload-stream.js
@@ -15,7 +15,9 @@ class S3MultipartUploadStream extends Writable {
     this.uploadId = null;
     this.partNumber = 1;
     this.multipartETags = [];
-    this.buffer = Buffer.alloc(0);
+    // accumulate incoming chunks to avoid O(n^2) Buffer.concat on every write
+    this.chunks = [];
+    this.bufferedBytes = 0;
     this.minPartSize = 5 * 1024 * 1024; // 5 MB
     this.s3 = new S3Client(opts.bucketCredential);
     this.metadata = opts.metadata;
@@ -31,13 +33,13 @@ class S3MultipartUploadStream extends Writable {
     return response.UploadId;
   }
 
-  async _uploadBuffer() {
+  async _uploadPart(bodyBuffer) {
     const uploadPartCommand = new UploadPartCommand({
       Bucket: this.bucketName,
       Key: this.objectKey,
       PartNumber: this.partNumber,
       UploadId: this.uploadId,
-      Body: this.buffer,
+      Body: bodyBuffer,
     });
 
     const uploadPartResponse = await this.s3.send(uploadPartCommand);
@@ -54,11 +56,16 @@ class S3MultipartUploadStream extends Writable {
         this.uploadId = await this._initMultipartUpload();
       }
 
-      this.buffer = Buffer.concat([this.buffer, chunk]);
+      // accumulate without concatenating on every write
+      this.chunks.push(chunk);
+      this.bufferedBytes += chunk.length;
 
-      if (this.buffer.length >= this.minPartSize) {
-        await this._uploadBuffer();
-        this.buffer = Buffer.alloc(0);
+      if (this.bufferedBytes >= this.minPartSize) {
+        const partBuffer = Buffer.concat(this.chunks, this.bufferedBytes);
+        // reset accumulators before awaiting upload to allow GC
+        this.chunks = [];
+        this.bufferedBytes = 0;
+        await this._uploadPart(partBuffer);
       }
 
       callback(null);
@@ -69,8 +76,11 @@ class S3MultipartUploadStream extends Writable {
 
   async _finalize(err) {
     try {
-      if (this.buffer.length > 0) {
-        await this._uploadBuffer();
+      if (this.bufferedBytes > 0) {
+        const finalBuffer = Buffer.concat(this.chunks, this.bufferedBytes);
+        this.chunks = [];
+        this.bufferedBytes = 0;
+        await this._uploadPart(finalBuffer);
       }
 
       const completeMultipartUploadCommand = new CompleteMultipartUploadCommand({

--- a/lib/record/upload.js
+++ b/lib/record/upload.js
@@ -51,8 +51,10 @@ async function upload(logger, socket) {
 
           /**encoder */
           let encoder;
+          let recordFormat;
           if (account[0].record_format === 'wav') {
             encoder = new wav.Writer({ channels: 2, sampleRate, bitDepth: 16 });
+            recordFormat = 'wav';
           } else {
             // default is mp3
             encoder = new PCMToMP3Encoder({
@@ -60,7 +62,9 @@ async function upload(logger, socket) {
               sampleRate: sampleRate,
               bitrate: 128
             }, logger);
+            recordFormat = 'mp3';
           }
+          logger.info({ record_format: recordFormat, channels: 2, sampleRate }, 'record upload: selected encoder');
 
           /* start streaming data */
           pipeline(


### PR DESCRIPTION
### Fix high CPU during call recording: optimize multipart upload buffering

- **Problem**
  - API servers exhibited high CPU utilization during call recording, causing slow API responses, failing health checks, and poor scaling behavior under load.
  - Trigger pattern: many concurrent recording WebSocket streams writing small audio chunks to S3 multipart uploads.

- **Root cause**
  - The multipart stream concatenated every incoming chunk with `Buffer.concat`, reallocating and copying the growing buffer on each write.
  - With thousands of tiny chunks per recording, total bytes copied grew O(n^2), driving excessive CPU and GC on the Node event loop.

- **Change**
  - Refactor `S3MultipartUploadStream` to accumulate chunks in an array and track total bytes.
  - Perform a single `Buffer.concat` per 5 MB part (or once at finalize) and upload that part.
  - No changes to S3 commands, metadata, or multipart semantics.

- **Impact**
  - Reduces buffer copying from O(n^2) to O(n) per part.
  - Lowers CPU and GC pressure during recording, improving request latency and stabilizing health checks under concurrency.
  - Transport/content-agnostic (WAV/MP3/etc.); behavior and object layout unchanged.

- **Validation**
  - Observed CPU regression risk removed in load tests; tail latency and health checks stabilized.

- **Operations**
  - No config or API changes required.