### PR TITLE
Allow disabling of all rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Configuration is provided via environment variables:
 |K8S_FEATURE_SERVER_SERVICE_PORT| feature server port(required for K8S) |no|
 |JAMBONZ_RECORD_WS_USERNAME| recording websocket username|no|
 |JAMBONZ_RECORD_WS_PASSWORD| recording websocket password|no|
+|DISABLE_RATE_LIMITS| disable rate limiting|no
 
 #### Database dependency
 A mysql database is used to store long-lived objects such as Accounts, Applications, etc. To create the database schema, use or review the scripts in the 'db' folder, particularly:

--- a/app.js
+++ b/app.js
@@ -170,7 +170,12 @@ if (process.env.JAMBONES_TRUST_PROXY) {
     });
   }
 }
-app.use(limiter);
+
+const disableRateLimit = process.env.DISABLE_RATE_LIMITS === 'true' || process.env.DISABLE_RATE_LIMITS === '1';
+
+if (!disableRateLimit) {
+  app.use(limiter);
+}
 app.use(helmet());
 app.use(helmet.hidePoweredBy());
 app.use(nocache());


### PR DESCRIPTION
As a user of the Jambonz API with my own service infront of it... I don't want any rate limiting. This PR allows for not adding the rate limit middleware if a new env variable is set thats documented in the README.

While I appreciate this setting could be _dangerous_, just setting the rate limit window as 1 minute and the rate limit per window to a super high number is exactly the same but the api still having to do rate limiting logic. This just makes it so the API isn't doing the extra work thats unnecessary.