### PR TITLE
force account sip_realm to lowercase

### DIFF
--- a/lib/routes/api/accounts.js
+++ b/lib/routes/api/accounts.js
@@ -560,6 +560,8 @@ router.post('/', async(req, res) => {
       }
       delete obj[prop];
     }
+    //force sip realm to lowercase
+    if (obj.sip_realm) { obj.sip_realm = obj.sip_realm.toLowerCase(); }
 
     logger.debug(`Attempting to add account ${JSON.stringify(obj)}`);
     const uuid = await Account.make(obj);
@@ -801,6 +803,9 @@ router.put('/:sid', async(req, res) => {
       }
 
       encryptBucketCredential(obj, storedBucketCredentials);
+
+      //force sip realm to lowercase
+      if (obj.sip_realm) { obj.sip_realm = obj.sip_realm.toLowerCase();}
 
       const rowsAffected = await Account.update(sid, obj);
       if (rowsAffected === 0) {


### PR DESCRIPTION
SIP realms should always be case insensitive, in the API or WebApp you can create one with upper case, this causes issues when trying to query clients by sip realm.

This PR ensures that they are always stored in lowercase in the database.