### PR TITLE
add srtp param to Create Call API

### DIFF
--- a/lib/swagger/swagger.yaml
+++ b/lib/swagger/swagger.yaml
@@ -3976,6 +3976,10 @@ paths:
                   type: string
                   description: The sip indialog hook to receive session messages
                   example: '/customHook'
+                srtp:
+                  type: boolean
+                  description: If true, use SRTP (SDES) for encrypted media. SDP will use RTP/SAVP with a=crypto lines.
+                  example: true
       responses:
         201:
           description: call successfully created


### PR DESCRIPTION
https://github.com/jambonz/jambonz-feature-server/issues/1538

Provides support for an srtp param on the Create Call API.

Goes with updates in jambonz-feature-server and sbc-outbound:
https://github.com/jambonz/jambonz-feature-server/pull/1539