### PR TITLE
fix: expand Homer SIP/PCAP queries to correlated Call-IDs

### DIFF
--- a/lib/utils/homer-utils.js
+++ b/lib/utils/homer-utils.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('jambonz:api-server');
+const { Pool } = require('pg');
 const basicAuth = (apiKey) => {
   const header = `Bearer ${apiKey}`;
   return {Authorization: header};
@@ -6,6 +7,75 @@ const basicAuth = (apiKey) => {
 const { Readable } = require('stream');
 const SEVEN_DAYS_IN_MS = (1000 * 3600 * 24 * 7);
 const HOMER_BASE_URL = process.env.HOMER_BASE_URL || 'http://127.0.0.1';
+
+let homerPool = null;
+const getHomerPool = () => {
+  if (!homerPool && process.env.HOMER_DB_HOST) {
+    homerPool = new Pool({
+      host: process.env.HOMER_DB_HOST,
+      port: parseInt(process.env.HOMER_DB_PORT || '5432', 10),
+      user: process.env.HOMER_DB_USER,
+      password: process.env.HOMER_DB_PASSWORD,
+      database: process.env.HOMER_DB_NAME || 'homer_data',
+      ssl: process.env.HOMER_DB_SSLMODE === 'disable' ? false : undefined,
+      max: 5,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 5000,
+    });
+  }
+  return homerPool;
+};
+
+/**
+ * Expand a single Call-ID to include all correlated Call-IDs found in Homer.
+ * Looks for rows in hep_proto_1_call where:
+ *   - the row's callid matches the requested id, OR
+ *   - the row's X-CID correlation_id matches the requested id
+ * Returns an array of unique Call-IDs (always includes the original).
+ */
+const expandHomerCallIds = async(logger, callId) => {
+  const pool = getHomerPool();
+  if (!pool) {
+    logger.debug('expandHomerCallIds: Homer DB not configured, using single callId');
+    return [callId];
+  }
+  try {
+    /*
+     * Two-hop expansion:
+     *   Hop 1 — direct: rows whose callid OR correlation_id equals the requested id.
+     *   Hop 2 — sibling: rows that share a correlation_id with any hop-1 row
+     *            (but whose correlation_id differs from the requested id, avoiding
+     *             the self-referential "correlation_id = callid" rows that heplify writes).
+     * This is needed because the jambonz call chain uses a common original carrier
+     * call-id as the correlation_id on both the SBC-FS leg and the FS-carrier leg,
+     * so the two legs are siblings rather than parent/child.
+     */
+    const result = await pool.query(
+      `SELECT DISTINCT data_header->>'callid' AS callid
+       FROM hep_proto_1_call
+       WHERE data_header->>'callid' = $1
+          OR protocol_header->>'correlation_id' = $1
+          OR protocol_header->>'correlation_id' IN (
+               SELECT DISTINCT protocol_header->>'correlation_id'
+               FROM hep_proto_1_call
+               WHERE data_header->>'callid' = $1
+                 AND protocol_header->>'correlation_id' != $1
+             )`,
+      [callId]
+    );
+    const ids = result.rows
+      .map((r) => r.callid)
+      .filter(Boolean);
+    const expanded = [...new Set([callId, ...ids])];
+    if (expanded.length > 1) {
+      logger.info({callId, expanded}, 'expandHomerCallIds: found correlated Call-IDs');
+    }
+    return expanded;
+  } catch (err) {
+    logger.warn({err, callId}, 'expandHomerCallIds: DB query failed, falling back to single callId');
+    return [callId];
+  }
+};
 
 const getHomerApiKey = async(logger) => {
   if (!process.env.HOMER_BASE_URL || !process.env.HOMER_USERNAME || !process.env.HOMER_PASSWORD) {
@@ -41,6 +111,7 @@ const getHomerSipTrace = async(logger, apiKey, callId) => {
     logger.debug('getHomerSipTrace: Homer integration not installed');
   }
   try {
+    const callIds = await expandHomerCallIds(logger, callId);
     const now = Date.now();
     const response = await fetch(`${HOMER_BASE_URL}/api/v3/call/transaction`, {
       method: 'POST',
@@ -58,10 +129,10 @@ const getHomerSipTrace = async(logger, apiKey, callId) => {
           orlogic: true,
           search: {
             '1_call': {
-              callid: [callId]
+              callid: callIds
             },
             '1_registration': {
-              callid: [callId]
+              callid: callIds
             }
           },
         },
@@ -87,6 +158,14 @@ const getHomerPcap = async(logger, apiKey, callIds, method) => {
     logger.debug('getHomerPcap: Homer integration not installed');
   }
   try {
+    const baseCallId = Array.isArray(callIds) ? callIds[0] : callIds;
+    const inputIds = Array.isArray(callIds) ? callIds : [callIds];
+    const expandedSets = await Promise.all(inputIds.map((id) => expandHomerCallIds(logger, id)));
+    const allIds = [...new Set(expandedSets.flat())];
+    if (allIds.length > inputIds.length) {
+      logger.info({baseCallId, allIds}, 'getHomerPcap: expanded to correlated Call-IDs');
+    }
+    const resolvedCallIds = allIds;
     const now = Date.now();
     const response = await fetch(`${HOMER_BASE_URL}/api/v3/export/call/messages/pcap`, {
       method: 'POST',
@@ -105,13 +184,12 @@ const getHomerPcap = async(logger, apiKey, callIds, method) => {
           search: {
             ...(method === 'invite' && {
               '1_call': {
-                callid: callIds
+                callid: resolvedCallIds
               }
-            })
-            ,
+            }),
             ...(method === 'register' && {
               '1_registration': {
-                callid: callIds
+                callid: resolvedCallIds
               }
             })
           },
@@ -128,11 +206,12 @@ const getHomerPcap = async(logger, apiKey, callIds, method) => {
     }
     return Readable.fromWeb(response.body);
   } catch (err) {
-    logger.info({err}, `getHomerPcap: Error retrieving messages for callid ${callIds}`);
+    logger.info({err}, `getHomerPcap: Error retrieving messages for callid ${baseCallId}`);
   }
 };
 
 module.exports = {
+  expandHomerCallIds,
   getHomerApiKey,
   getHomerSipTrace,
   getHomerPcap

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "nocache": "4.0.0",
         "passport": "^0.7.0",
         "passport-http-bearer": "^1.0.1",
+        "pg": "^8.22.0",
         "pino": "^8.20.0",
         "short-uuid": "^4.2.2",
         "speechmatics": "^4.0.0",
@@ -9215,6 +9216,95 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9353,6 +9443,45 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "nocache": "4.0.0",
     "passport": "^0.7.0",
     "passport-http-bearer": "^1.0.1",
+    "pg": "^8.22.0",
     "pino": "^8.20.0",
     "short-uuid": "^4.2.2",
     "speechmatics": "^4.0.0",


### PR DESCRIPTION
## Summary
- Recent-call SIP traces / PCAP exports previously queried Homer with a single Call-ID (usually the carrier/SBC leg).
- Feature-server leg SIP (including mid-call INFO DTMF captured in HEP) lives under a different Call-ID linked by `X-CID` / `correlation_id`.
- Before calling Homer, expand to all related Call-IDs via `hep_proto_1_call` (`callid` / `correlation_id`, two-hop sibling lookup) and pass the full list into the existing Homer APIs.

## Config
When Homer DB credentials are available, set:

- `HOMER_DB_HOST`
- `HOMER_DB_PORT` (default `5432`)
- `HOMER_DB_USER`
- `HOMER_DB_PASSWORD`
- `HOMER_DB_NAME` (default `homer_data`)
- `HOMER_DB_SSLMODE` (`disable` supported)

If unset, behavior is unchanged (single Call-ID).

## Test plan
- [ ] Place a call that produces SBC + feature-server SIP legs with FS INVITE `X-CID` = carrier Call-ID
- [ ] Confirm HEP has INFO (or other FS-leg SIP) under the FS Call-ID
- [ ] Download PCAP / open SIP ladder for the carrier Call-ID from the portal
- [ ] Confirm export includes both legs (and INFO when present)
- [ ] Confirm without `HOMER_DB_*` configured, single-Call-ID behavior still works


Made with [Cursor](https://cursor.com)