### PR TITLE
feat(tts): add inworld-tts-2 and deprecate the tts-1 generation

### DIFF
--- a/lib/utils/speech-data/tts-model-inworld.js
+++ b/lib/utils/speech-data/tts-model-inworld.js
@@ -1,7 +1,12 @@
 module.exports = [
+  { name: 'Inworld TTS 2', value: 'inworld-tts-2' },
   { name: 'Llama Inworld TTS 1.5 Max', value: 'inworld-tts-1.5-max' },
   { name: 'Llama Inworld TTS 1.5 Mini', value: 'inworld-tts-1.5-mini' },
-  { name: 'Llama Inworld TTS', value: 'inworld-tts-1' },
-  { name: 'Llama Inworld TTS Max', value: 'inworld-tts-1-max' },
+  /* the tts-1 generation returns no word timestamps, so it cannot support
+     playout tracking / alignment-based barge-in; kept selectable for existing
+     credentials but no longer offered as the default
+   */
+  { name: 'Llama Inworld TTS (Deprecated)', value: 'inworld-tts-1' },
+  { name: 'Llama Inworld TTS Max (Deprecated)', value: 'inworld-tts-1-max' },
 ];
 


### PR DESCRIPTION
Inworld's `tts-1` and `tts-1-max` return no word timestamps, so they cannot support playout tracking or alignment-based barge-in. Only the 1.5 models and `inworld-tts-2` do.

- adds `inworld-tts-2` at the head of the list — the portal preselects `ttsModels[0]` for a new credential, so this becomes the default
- marks `inworld-tts-1` and `inworld-tts-1-max` `(Deprecated)`, following the existing ElevenLabs convention

Both deprecated entries stay in the list and remain selectable, so existing credentials pinned to them keep working — the webapp only overrides a stored `model_id` when it is missing from the returned list.

Part of Inworld streaming TTS support: jambonz/mediajam#94, jambonz/feature-server#165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)