### PR TITLE
feat(tts): add Inworld TTS 2 and TTS 2 Flash models

### DIFF
--- a/lib/utils/speech-data/tts-model-inworld.js
+++ b/lib/utils/speech-data/tts-model-inworld.js
@@ -1,7 +1,8 @@
 module.exports = [
+  { name: 'Inworld TTS 2', value: 'inworld-tts-2' },
+  { name: 'Inworld TTS 2 Flash', value: 'inworld-tts-2-flash' },
   { name: 'Llama Inworld TTS 1.5 Max', value: 'inworld-tts-1.5-max' },
   { name: 'Llama Inworld TTS 1.5 Mini', value: 'inworld-tts-1.5-mini' },
   { name: 'Llama Inworld TTS', value: 'inworld-tts-1' },
   { name: 'Llama Inworld TTS Max', value: 'inworld-tts-1-max' },
 ];
-


### PR DESCRIPTION
- add inworld-tts-2 and inworld-tts-2-flash to the Inworld model list
- both return word timestamps; flash is the low-latency/low-cost variant
- model_id is passed through unchanged, so no other wiring is needed